### PR TITLE
without casting fps to int, this math sometimes doesn't work right

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -4054,7 +4054,7 @@ static void limitFF(void) {
 	static int last_max_speed = -1;
 	if (last_max_speed!=max_ff_speed) {
 		last_max_speed = max_ff_speed;
-		ff_frame_time = 1000000 / (core.fps * (max_ff_speed + 1));
+		ff_frame_time = 1000000 / ((int)core.fps * (max_ff_speed + 1));
 	}
 	
 	uint64_t now = getMicroseconds();


### PR DESCRIPTION
In the archived rg35xx version, not casting fps to int could result in a massive delay value. This may not be required, but maybe cheap insurance?