### PR TITLE
RTC implementation

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -420,6 +420,55 @@ static void SRAM_write(void) {
 
 ///////////////////////////////////////
 
+static void RTC_getPath(char* filename) {
+	sprintf(filename, "%s/%s.rtc", core.saves_dir, game.name);
+}
+static void RTC_read(void) {
+	size_t rtc_size = core.get_memory_size(RETRO_MEMORY_RTC);
+	if (!rtc_size) return;
+	
+	char filename[MAX_PATH];
+	RTC_getPath(filename);
+	printf("rtc path (read): %s\n", filename);
+	
+	FILE *rtc_file = fopen(filename, "r");
+	if (!rtc_file) return;
+
+	void* rtc = core.get_memory_data(RETRO_MEMORY_RTC);
+
+	if (!rtc || !fread(rtc, 1, rtc_size, rtc_file)) {
+		LOG_error("Error reading RTC data\n");
+	}
+
+	fclose(rtc_file);
+}
+static void RTC_write(void) {
+	size_t rtc_size = core.get_memory_size(RETRO_MEMORY_RTC);
+	if (!rtc_size) return;
+	
+	char filename[MAX_PATH];
+	RTC_getPath(filename);
+	printf("rtc path (write) size(%u): %s\n", rtc_size, filename);
+		
+	FILE *rtc_file = fopen(filename, "w");
+	if (!rtc_file) {
+		LOG_error("Error opening RTC file: %s\n", strerror(errno));
+		return;
+	}
+
+	void *rtc = core.get_memory_data(RETRO_MEMORY_RTC);
+
+	if (!rtc || rtc_size != fwrite(rtc, 1, rtc_size, rtc_file)) {
+		LOG_error("Error writing RTC data to file\n");
+	}
+
+	fclose(rtc_file);
+
+	sync();
+}
+
+///////////////////////////////////////
+
 static int state_slot = 0;
 static void State_getPath(char* filename) {
 	sprintf(filename, "%s/%s.st%i", core.states_dir, game.name, state_slot);
@@ -2303,6 +2352,7 @@ void Core_load(void) {
 	core.load_game(&game_info);
 	
 	SRAM_read();
+	RTC_read();
 	
 	// NOTE: must be called after core.load_game!
 	struct retro_system_av_info av_info = {};
@@ -2325,6 +2375,7 @@ void Core_unload(void) {
 void Core_quit(void) {
 	if (core.initialized) {
 		SRAM_write();
+		RTC_write();
 		core.unload_game();
 		core.deinit();
 		core.initialized = 0;
@@ -2439,6 +2490,7 @@ void Menu_quit(void) {
 }
 void Menu_beforeSleep(void) {
 	SRAM_write();
+	RTC_write();
 	State_autosave();
 	putFile(AUTO_RESUME_PATH, game.path + strlen(SDCARD_PATH));
 	PWR_setCPUSpeed(CPU_SPEED_MENU);
@@ -3474,6 +3526,7 @@ static void Menu_loop(void) {
 	}
 	
 	SRAM_write();
+	RTC_write();
 	PWR_warn(0);
 	if (!HAS_POWER_BUTTON) PWR_enableSleep();
 	PWR_setCPUSpeed(CPU_SPEED_MENU); // set Hz directly


### PR DESCRIPTION
## Why was this done?

Games like `Pokemon Crystal` uses a hardware RTC to function properly. Even though the `RG35XX` and `gambatte` libretro core supports this feature, for some reason, it was not properly working with MinUI.

Everytime the game booted, the clock would not tick forward.

## What was done?

Implemented the functions `RTC_getPath`, `RTC_read` and `RTC_write` on `miniarch`. This should write a `.rtc` file to the SD card.

They were implemented by reading and writing to `RETRO_MEMORY_RTC` based on the current SRAM read/write functions.

## How was this tested?

This was tested on a `RG35XX` device on **gambatte** libretro core. If the game supports RTC (`core.get_memory_size(RETRO_MEMORY_RTC)`  returns a value greater than zero) a `.rtc` file is created and loaded according to MinUIs lifecycle.

If the game does not support RTC, the core `core.get_memory_size(RETRO_MEMORY_RTC)` will return a zero value and no `.rtc` file will be created.

## Possible improvements

 - Everywhere that `SRAM_read` and `SRAM_write` is called, so should `RTC_read` and `RTC_write`. For simplicity, I left those as two separate  calls, but they can be merged in a `SRAM_RTC_write` and `SRAM_RTC_read` functions. Also, the `sync()` call can be  moved to this new function on the `*_write` calls, but this may be controversial since the other functions arent treated as private it could cause some confusion when the filesystem is not flushed.
 - Both `SRAM_*` and `RTC_*` shares a lot of code, they may be merged into a single funcion. For the sake  of simplicity, I did not do this on this pull request

## Closing

Finally, I don´t know how you feels about contributions to your project. I did this mainly for personal use because MinUI is my favorite frontend for my old Miyoo Mini and now for the RG35XX.

Hope this PR does more good than harm :)