### PR TITLE
Fix mono sound on headphones for M17

### DIFF
--- a/workspace/m17/libmsettings/msettings.c
+++ b/workspace/m17/libmsettings/msettings.c
@@ -155,7 +155,7 @@ void SetRawBrightness(int val) { // 8000-0 (>8000 == off)
 void SetRawVolume(int val) { // 0 - 100
 	printf("SetRawVolume(%i)\n", val); fflush(stdout);
 	char cmd[256];
-	sprintf(cmd, "amixer sset -M 'Master' %i%% &> /dev/null", val);
+	sprintf(cmd, "amixer sset -M 'Master' %i%%,0 &> /dev/null", val);
 	// puts(cmd); fflush(stdout);
 	system(cmd);
 }


### PR DESCRIPTION
For M17 console, the same mono sound is coming out to both speakers twice, L sound to L and R speaker and R sound (same sound) to L and R speakers as well. 
The solution is to mute R speaker in alsamixer and the L mono sound will get out to both speakers.