### PR TITLE
FIX (minarch): some cores need configure a default controller.

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -2393,7 +2393,10 @@ void Core_load(void) {
 	// NOTE: must be called after core.load_game!
 	struct retro_system_av_info av_info = {};
 	core.get_system_av_info(&av_info);
-	
+
+	// FIX: some cores need configure a default controller.
+	core.set_controller_port_device(0, 1);
+
 	core.fps = av_info.timing.fps;
 	core.sample_rate = av_info.timing.sample_rate;
 	double a = av_info.geometry.aspect_ratio;


### PR DESCRIPTION
Hello @shauninman thanks for your really good job, I love your UI!

I added a missing controller configure that is need it by some cores :)

### Why?
libretro-cap32 emulator raise a segmentation fault when use MinUI-minarch implementation.

### How was this tested?
Tested on rg35xx with libretro-cap32 emulator.

Thanks!