### PR TITLE
all: fix fceumm compilation

### DIFF
--- a/workspace/m17/cores/patches/fceumm.patch
+++ b/workspace/m17/cores/patches/fceumm.patch
@@ -12,7 +12,7 @@ index 036c41f48b087c99b2276b2d41a71d661fd85145..891eb96ceeb1da868d6d2ed40392b51b
 +	CC = $(CROSS_COMPILE)gcc
 +	CXX = $(CROSS_COMPILE)g++
 +	AR = $(CROSS_COMPILE)ar
-+	SHARED := -shared -Wl,--version-script=src/drivers/libretro/link.T -Wl,-no-undefined
++	SHARED := -shared -Wl,--version-script=src/libretro/link.T -Wl,-no-undefined
 +	LDFLAGS += -fPIC -flto
 +	CFLAGS += -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -mcpu=cortex-a7
 +	CFLAGS += -fomit-frame-pointer -ffast-math -fPIC -flto

--- a/workspace/miyoomini/cores/patches/fceumm.patch
+++ b/workspace/miyoomini/cores/patches/fceumm.patch
@@ -12,7 +12,7 @@ index 036c41f48b087c99b2276b2d41a71d661fd85145..891eb96ceeb1da868d6d2ed40392b51b
 +	CC = $(CROSS_COMPILE)gcc
 +	CXX = $(CROSS_COMPILE)g++
 +	AR = $(CROSS_COMPILE)ar
-+	SHARED := -shared -Wl,--version-script=src/drivers/libretro/link.T -Wl,-no-undefined
++	SHARED := -shared -Wl,--version-script=src/libretro/link.T -Wl,-no-undefined
 +	LDFLAGS += -fPIC -flto
 +	CFLAGS += -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -march=armv7ve
 +	CFLAGS += -fomit-frame-pointer -ffast-math -fPIC -flto

--- a/workspace/rg35xx/cores/patches/fceumm.patch
+++ b/workspace/rg35xx/cores/patches/fceumm.patch
@@ -12,7 +12,7 @@ index 14b8cbedb12860aedc2bc21119735247929bdbd3..0d1787ef81ffc6cdb2b4982c779a89ef
 +   CC = $(CROSS_COMPILE)gcc
 +   CXX = $(CROSS_COMPILE)g++
 +   AR = $(CROSS_COMPILE)ar
-+   SHARED := -shared -Wl,--version-script=src/drivers/libretro/link.T -Wl,-no-undefined
++   SHARED := -shared -Wl,--version-script=src/libretro/link.T -Wl,-no-undefined
 +   LDFLAGS += -fPIC -flto
 +   CFLAGS += -marm -mtune=cortex-a9 -mfpu=neon-fp16 -mfloat-abi=hard -march=armv7-a -fomit-frame-pointer
 +   CFLAGS += -fomit-frame-pointer -ffast-math -fPIC -flto

--- a/workspace/rgb30/cores/patches/fceumm.patch
+++ b/workspace/rgb30/cores/patches/fceumm.patch
@@ -13,7 +13,7 @@ index 0cd567cf174249e92a43c4c78be582ba4c36a57c..2597db6a4fe1a1c4a4a9dd5e42de37f5
 +	CXX = $(CROSS_COMPILE)g++
 +	AR = $(CROSS_COMPILE)ar
 +	fpic := -fPIC
-+	SHARED := -shared -Wl,--version-script=src/drivers/libretro/link.T -Wl,-no-undefined
++	SHARED := -shared -Wl,--version-script=src/libretro/link.T -Wl,-no-undefined
 +	PLATFORM_DEFINES += -fomit-frame-pointer -ffast-math -mtune=cortex-a55 -march=armv8.2-a 
 +	EXTERNAL_ZLIB = 1
 +

--- a/workspace/tg5040/cores/patches/fceumm.patch
+++ b/workspace/tg5040/cores/patches/fceumm.patch
@@ -12,7 +12,7 @@ index 036c41f48b087c99b2276b2d41a71d661fd85145..891eb96ceeb1da868d6d2ed40392b51b
 +	CC = $(CROSS_COMPILE)gcc
 +	CXX = $(CROSS_COMPILE)g++
 +	AR = $(CROSS_COMPILE)ar
-+	SHARED := -shared -Wl,--version-script=src/drivers/libretro/link.T -Wl,-no-undefined
++	SHARED := -shared -Wl,--version-script=src/libretro/link.T -Wl,-no-undefined
 +	LDFLAGS += -fPIC -flto
 +	CFLAGS += -mtune=cortex-a53 -mcpu=cortex-a53 -march=armv8-a
 +	CFLAGS += -fomit-frame-pointer -ffast-math -fPIC -flto

--- a/workspace/trimui/cores/patches/fceumm.patch
+++ b/workspace/trimui/cores/patches/fceumm.patch
@@ -12,7 +12,7 @@ index 036c41f48b087c99b2276b2d41a71d661fd85145..09b4281eb23df7d3932b1d4751ba5aeb
 +  CC  = $(CROSS_COMPILE)gcc
 +  CXX = $(CROSS_COMPILE)g++
 +  AR  = $(CROSS_COMPILE)ar
-+  SHARED := -shared -Wl,--version-script=src/drivers/libretro/link.T -Wl,-no-undefined
++  SHARED := -shared -Wl,--version-script=src/libretro/link.T -Wl,-no-undefined
 +  PLATFORM_DEFINES += -fomit-frame-pointer -ffast-math -mcpu=arm926ej-s
 +  EXTERNAL_ZLIB = 1
 +

--- a/workspace/trimuismart/cores/patches/fceumm.patch
+++ b/workspace/trimuismart/cores/patches/fceumm.patch
@@ -12,7 +12,7 @@ index 036c41f48b087c99b2276b2d41a71d661fd85145..891eb96ceeb1da868d6d2ed40392b51b
 +	CC = $(CROSS_COMPILE)gcc
 +	CXX = $(CROSS_COMPILE)g++
 +	AR = $(CROSS_COMPILE)ar
-+	SHARED := -shared -Wl,--version-script=src/drivers/libretro/link.T -Wl,-no-undefined
++	SHARED := -shared -Wl,--version-script=src/libretro/link.T -Wl,-no-undefined
 +	LDFLAGS += -fPIC -flto
 +	CFLAGS += -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -mcpu=cortex-a7
 +	CFLAGS += -fomit-frame-pointer -ffast-math -fPIC -flto


### PR DESCRIPTION
https://github.com/libretro/libretro-fceumm/commit/4c90e6a8a37322d13d5190de9e30fe4bfe64ca37 introduced a breaking change by moving the location of the link.T file.