### PR TITLE
miyoo: build overclock

### DIFF
--- a/workspace/miyoomini/makefile
+++ b/workspace/miyoomini/makefile
@@ -18,6 +18,7 @@ all: readmes
 	cd batmon && make
 	cd lumon && make
 	cd show && make
+	cd overclock && make
 
 early: $(REQUIRES_SDL) $(REQUIRES_COMMANDER)
 	cd other/sdl && ./make.sh


### PR DESCRIPTION
It is expected that overclock is built and copied over. This change makes sure overclock.elf is compiled.