### PR TITLE
rgb30: fix swapped volume buttons in keymon.c

### DIFF
--- a/workspace/rgb30/keymon/keymon.c
+++ b/workspace/rgb30/keymon/keymon.c
@@ -19,8 +19,8 @@
 #define CODE_MENU 317 // 11 in SDL for some reason...
 #define CODE_MENU_ALT 318 // 12 in SDL...
 
-#define CODE_PLUS 114
-#define CODE_MINUS 115
+#define CODE_PLUS 115
+#define CODE_MINUS 114
 
 #define VOLUME_MIN 		0
 #define VOLUME_MAX 		20


### PR DESCRIPTION
My observation shows that you swapped the volume buttons. The left button is volume-up.  This may also result in the problem, that the volume control is not that reliable and has some jittery behavior. I think you also mentioned this in your TODO. Maybe its not only because of the swapped button, but because the JELOS (MOSS) base does still handle the buttons itself and keymon interferes with this separate handling.