### PR TITLE
fix stack-user-after-scope

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -551,12 +551,13 @@ void GFX_blitRect(int asset, SDL_Surface* dst, SDL_Rect* dst_rect) {
 }
 void GFX_blitBattery(SDL_Surface* dst, SDL_Rect* dst_rect) {
 	// LOG_info("dst: %p\n", dst);
-	
-	if (!dst_rect) dst_rect = &(SDL_Rect){0,0,0,0};
-	
+	int x = 0;
+	int y = 0;
+	if (dst_rect) {
+		x = dst_rect->x;
+		y = dst_rect->y;
+	}
 	SDL_Rect rect = asset_rects[ASSET_BATTERY];
-	int x = dst_rect->x;
-	int y = dst_rect->y;
 	x += (SCALE1(PILL_SIZE) - (rect.w + FIXED_SCALE)) / 2;
 	y += (SCALE1(PILL_SIZE) - rect.h) / 2;
 	


### PR DESCRIPTION
Found this with address sanitizer.
Defined SDL_Rect is invalid after if block.