### PR TITLE
added reset game in options

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -3004,6 +3004,12 @@ static int OptionQuicksave_onConfirm(MenuList* list, int i) {
 	PWR_powerOff();
 }
 
+static int OptionResetGame(MenuList* list, int i) {
+	Core_reset();
+	show_menu = 0;
+	return MENU_CALLBACK_EXIT;
+}
+
 static MenuList options_menu = {
 	.type = MENU_LIST,
 	.items = (MenuItem[]) {
@@ -3012,7 +3018,7 @@ static MenuList options_menu = {
 		{"Controls",.on_confirm=OptionControls_openMenu},
 		{"Shortcuts",.on_confirm=OptionShortcuts_openMenu}, 
 		{"Save Changes",.on_confirm=OptionSaveChanges_openMenu},
-		{NULL},
+		{"Reset Game",.on_confirm=OptionResetGame},
 		{NULL},
 		{NULL},
 	}


### PR DESCRIPTION
It bugged me that I couldn't play disc 2 of Resident Evil 2 (Game hangs after disc change).
Found out I can define and use a shortcut after reading the code :D

I like that MinUI does not have any hidden shortcuts for basic use cases so maybe the "reset game" belongs to the options?