### PR TITLE
Tweaks to RGB30 native P8; File Browser for RG35xxplus

### DIFF
--- a/skeleton/EXTRAS/Emus/rgb30/P8-NATIVE.pak/launch.sh
+++ b/skeleton/EXTRAS/Emus/rgb30/P8-NATIVE.pak/launch.sh
@@ -6,8 +6,16 @@ PICO8_DIR="$SDCARD_PATH/Tools/$PLATFORM/Splore.pak/pico-8"
 if [ ! -d "$PICO8_DIR" ]; then
 	show.elf "$DIR/missing.png" 4
 	exit
+# add sdl controller file if not present in pico-8 folder
+elif [ ! -f "$PICO8_DIR/sdl_controllers.txt" ]; then
+	cp "$DIR/sdl_controllers.txt" "$PICO8_DIR";
+fi
+
+# ensure correct sdl controller file for rgb30 is in use
+cmp -s "$DIR/sdl_controllers.txt" "$PICO8_DIR/sdl_controllers.txt"
+if [ "$?" -eq 1 ]; then
+	cp -f "$DIR/sdl_controllers.txt" "$PICO8_DIR";
 fi
 
 cd "$PICO8_DIR"
 ./pico8_64 -run "$1" -pixel_perfect 1 -joystick 0
-

--- a/skeleton/EXTRAS/Tools/rg35xxplus/File Browser.pak/launch.sh
+++ b/skeleton/EXTRAS/Tools/rg35xxplus/File Browser.pak/launch.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cd /mnt/vendor/bin/fileM
-./dinguxCommand_en.dge > ./log.txt 2>&1

--- a/skeleton/EXTRAS/Tools/rg35xxplus/File Browser.pak/launch.sh
+++ b/skeleton/EXTRAS/Tools/rg35xxplus/File Browser.pak/launch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /mnt/vendor/bin/fileM
+./dinguxCommand_en.dge > ./log.txt 2>&1

--- a/skeleton/EXTRAS/Tools/rgb30/Splore.pak/launch.sh
+++ b/skeleton/EXTRAS/Tools/rgb30/Splore.pak/launch.sh
@@ -35,4 +35,10 @@ if [ ! -d ./pico-8 ]; then
 	fi
 fi
 
+# ensure correct sdl controller file is in place
+cmp -s "$DIR/sdl_controllers.txt" "$DIR/pico-8/sdl_controllers.txt"
+if [ "$?" -eq 1 ]; then
+	cp ./sdl_controllers.txt ./pico-8;
+fi
+
 cd ./pico-8 && ./pico8_64 -splore -pixel_perfect 1 -joystick 0


### PR DESCRIPTION
Added a few checks in the launch scripts for Splore.pak and P8-NATIVE.pak for the RGB30 to ensure that the correct SDL controller files are being used for that device, to ensure compatibility when Pico-8 is being used cross-platform, as with my mods for the RG35xxplus line.

Added my File Browser.pak for the rg35xxplus line, which just taps into the stock OS's file browser. This could be handy for users who wish to either migrate their ROMs over from their Stock OS SD card to the appropriate MinUI folders, or even just for general troubleshooting such as the checking of log files. (I've used it to write whole bash scripts on-device at times ;;>_> )