### PR TITLE
Add deep sleep support

### DIFF
--- a/skeleton/SYSTEM/tg3040/bin/suspend
+++ b/skeleton/SYSTEM/tg3040/bin/suspend
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -euo pipefail
+exec 0<&-
+
+wpa_running=
+hciattach_running=
+bluetoothd_running=
+
+before() {
+	>&2 echo "Preparing for suspend..."
+
+	if pgrep wpa_supplicant; then
+		wpa_running=1
+		>&2 echo "Stopping wpa_supplicant..."
+		killall -9 wpa_supplicant || true
+	fi
+	ifconfig wlan0 down || true
+
+	if pgrep hciattach; then
+		hciattach_running=1
+		>&2 echo "Stopping hciattach..."
+		/etc/init.d/hciattach stop || true
+	fi
+	if pgrep bluetoothd; then
+		bluetoothd_running=1
+		>&2 echo "Stopping bluetoothd..."
+		/etc/bluetooth/bluetoothd stop || true
+		killall -15 bluealsa || true
+	fi
+
+	>&2 echo "Blocking wireless..."
+	echo 0 >/sys/class/rfkill/rfkill0/state || true
+}
+
+after() {
+	>&2 echo "Resumed from suspend."
+
+	>&2 echo "Unblocking wireless..."
+	echo 1 >/sys/class/rfkill/rfkill0/state || true
+
+	if [ -n "$wpa_running" ]; then
+		>&2 echo "Starting wpa_supplicant..."
+		wpa_supplicant -B -D nl80211 -iwlan0 -c /etc/wifi/wpa_supplicant.conf -O /etc/wifi/sockets || true
+		(( udhcpc -i wlan0 &)&)
+	fi
+
+	if [ -n "$hciattach_running" ]; then
+		>&2 echo "Starting hciattach..."
+		/etc/init.d/hciattach start || true
+	fi
+	if [ -n "$bluetoothd_running" ]; then
+		>&2 echo "Starting bluetoothd..."
+		/etc/bluetooth/bluetoothd start || true
+		/usr/bin/bluetoothctl power on || true
+	fi
+}
+
+before
+
+>&2 echo "Suspending..."
+echo mem >/sys/power/state
+
+# Resume services in background to reduce UI latency
+(( after &)&)

--- a/skeleton/SYSTEM/tg3040/bin/suspend
+++ b/skeleton/SYSTEM/tg3040/bin/suspend
@@ -6,8 +6,14 @@ wpa_running=
 hciattach_running=
 bluetoothd_running=
 
+asound_state_dir=/tmp/asound-suspend
+
 before() {
 	>&2 echo "Preparing for suspend..."
+
+	>&2 echo "Saving mixer state..."
+	mkdir -p "$asound_state_dir"
+	alsactl --file "$asound_state_dir/asound.state.pre" store || true
 
 	if pgrep wpa_supplicant; then
 		wpa_running=1
@@ -34,6 +40,10 @@ before() {
 
 after() {
 	>&2 echo "Resumed from suspend."
+
+	>&2 echo "Restoring mixer state..."
+	alsactl --file "$asound_state_dir/asound.state.post" store || true
+	alsactl --file "$asound_state_dir/asound.state.pre" restore || true
 
 	>&2 echo "Unblocking wireless..."
 	echo 1 >/sys/class/rfkill/rfkill0/state || true

--- a/skeleton/SYSTEM/tg5040/bin/suspend
+++ b/skeleton/SYSTEM/tg5040/bin/suspend
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -euo pipefail
+exec 0<&-
+
+wpa_running=
+hciattach_running=
+bluetoothd_running=
+
+before() {
+	>&2 echo "Preparing for suspend..."
+
+	if pgrep wpa_supplicant; then
+		wpa_running=1
+		>&2 echo "Stopping wpa_supplicant..."
+		killall -9 wpa_supplicant || true
+	fi
+	ifconfig wlan0 down || true
+
+	if pgrep hciattach; then
+		hciattach_running=1
+		>&2 echo "Stopping hciattach..."
+		/etc/init.d/hciattach stop || true
+	fi
+	if pgrep bluetoothd; then
+		bluetoothd_running=1
+		>&2 echo "Stopping bluetoothd..."
+		/etc/bluetooth/bluetoothd stop || true
+		killall -15 bluealsa || true
+	fi
+
+	>&2 echo "Blocking wireless..."
+	echo 0 >/sys/class/rfkill/rfkill0/state || true
+}
+
+after() {
+	>&2 echo "Resumed from suspend."
+
+	>&2 echo "Unblocking wireless..."
+	echo 1 >/sys/class/rfkill/rfkill0/state || true
+
+	if [ -n "$wpa_running" ]; then
+		>&2 echo "Starting wpa_supplicant..."
+		wpa_supplicant -B -D nl80211 -iwlan0 -c /etc/wifi/wpa_supplicant.conf -O /etc/wifi/sockets || true
+		(( udhcpc -i wlan0 &)&)
+	fi
+
+	if [ -n "$hciattach_running" ]; then
+		>&2 echo "Starting hciattach..."
+		/etc/init.d/hciattach start || true
+	fi
+	if [ -n "$bluetoothd_running" ]; then
+		>&2 echo "Starting bluetoothd..."
+		/etc/bluetooth/bluetoothd start || true
+		/usr/bin/bluetoothctl power on || true
+	fi
+}
+
+before
+
+>&2 echo "Suspending..."
+echo mem >/sys/power/state
+
+# Resume services in background to reduce UI latency
+(( after &)&)

--- a/skeleton/SYSTEM/tg5040/bin/suspend
+++ b/skeleton/SYSTEM/tg5040/bin/suspend
@@ -6,8 +6,14 @@ wpa_running=
 hciattach_running=
 bluetoothd_running=
 
+asound_state_dir=/tmp/asound-suspend
+
 before() {
 	>&2 echo "Preparing for suspend..."
+
+	>&2 echo "Saving mixer state..."
+	mkdir -p "$asound_state_dir"
+	alsactl --file "$asound_state_dir/asound.state.pre" store || true
 
 	if pgrep wpa_supplicant; then
 		wpa_running=1
@@ -34,6 +40,10 @@ before() {
 
 after() {
 	>&2 echo "Resumed from suspend."
+
+	>&2 echo "Restoring mixer state..."
+	alsactl --file "$asound_state_dir/asound.state.post" store || true
+	alsactl --file "$asound_state_dir/asound.state.pre" restore || true
 
 	>&2 echo "Unblocking wireless..."
 	echo 1 >/sys/class/rfkill/rfkill0/state || true

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -267,8 +267,7 @@ void PWR_disablePowerOff(void);
 void PWR_powerOff(void);
 int PWR_isPoweringOff(void);
 
-void PWR_fauxSleep(void);
-void PWR_deepSleep(void);
+void PWR_sleep(void);
 
 void PWR_disableSleep(void);
 void PWR_enableSleep(void);

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -268,6 +268,7 @@ void PWR_powerOff(void);
 int PWR_isPoweringOff(void);
 
 void PWR_sleep(void);
+int PWR_deepSleep(void);
 
 void PWR_disableSleep(void);
 void PWR_enableSleep(void);

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -268,6 +268,7 @@ void PWR_powerOff(void);
 int PWR_isPoweringOff(void);
 
 void PWR_fauxSleep(void);
+void PWR_deepSleep(void);
 
 void PWR_disableSleep(void);
 void PWR_enableSleep(void);
@@ -318,6 +319,8 @@ void PLAT_enableOverlay(int enable);
 #define PWR_LOW_CHARGE 10
 void PLAT_getBatteryStatus(int* is_charging, int* charge); // 0,1 and 0,10,20,40,60,80,100
 void PLAT_enableBacklight(int enable);
+int PLAT_supportsDeepSleep(void);
+int PLAT_deepSleep(void);
 void PLAT_powerOff(void);
 	
 void PLAT_setCPUSpeed(int speed); // enum

--- a/workspace/all/common/defines.h
+++ b/workspace/all/common/defines.h
@@ -18,6 +18,7 @@
 #define USERDATA_PATH SDCARD_PATH "/.userdata/" PLATFORM
 #define SHARED_USERDATA_PATH SDCARD_PATH "/.userdata/shared"
 #define PAKS_PATH SYSTEM_PATH "/paks"
+#define BIN_PATH SYSTEM_PATH "/bin"
 #define RECENT_PATH SHARED_USERDATA_PATH "/.minui/recent.txt"
 #define SIMPLE_MODE_PATH SHARED_USERDATA_PATH "/enable-simple-mode"
 #define AUTO_RESUME_PATH SHARED_USERDATA_PATH "/.minui/auto_resume.txt"

--- a/workspace/tg3040/platform/platform.c
+++ b/workspace/tg3040/platform/platform.c
@@ -522,6 +522,8 @@ void PLAT_powerOff(void) {
 	while (1) pause(); // lolwat
 }
 
+int PLAT_supportsDeepSleep(void) { return 1; }
+
 ///////////////////////////////
 
 #define GOVERNOR_PATH "/sys/devices/system/cpu/cpu0/cpufreq/scaling_setspeed"

--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -515,6 +515,8 @@ void PLAT_powerOff(void) {
 	while (1) pause(); // lolwat
 }
 
+int PLAT_supportsDeepSleep(void) { return 1; }
+
 ///////////////////////////////
 
 #define GOVERNOR_PATH "/sys/devices/system/cpu/cpu0/cpufreq/scaling_setspeed"


### PR DESCRIPTION
This PR implements deep sleep (suspend-to-RAM) on Trimui Brick and Smart Pro. The device enters deep sleep instead of powering off after 2 minutes of faux sleep, making resumption much faster (~1s) than a cold boot (~15s) with negligible battery drain (~3% per day). The stock UI on those two devices also uses deep sleep so this should be safe.

The 2-minute faux sleep is preserved to make the UX snappy for short pauses. To immediately enter deep sleep after pressing the power button, revert the "all: Enter deep sleep after 2 minutes of faux sleep" commit.