### PR TITLE
TrimUI Brick Audio Fixes

### DIFF
--- a/workspace/tg3040/libmsettings/msettings.h
+++ b/workspace/tg3040/libmsettings/msettings.h
@@ -8,7 +8,7 @@ int GetBrightness(void);
 int GetVolume(void);
 
 void SetRawBrightness(int value); // 0-255
-void SetRawVolume(int value); // 0-160
+void SetRawVolume(int value); // 0-100
 
 void SetBrightness(int value); // 0-10
 void SetVolume(int value); // 0-20

--- a/workspace/tg3040/platform/platform.h
+++ b/workspace/tg3040/platform/platform.h
@@ -129,7 +129,7 @@
 ///////////////////////////////
 
 #define SDCARD_PATH "/mnt/SDCARD"
-#define MUTE_VOLUME_RAW 63 // 0 unintuitively is 100% volume
+#define MUTE_VOLUME_RAW 0
 
 ///////////////////////////////
 


### PR DESCRIPTION
TrimUI brick has a few issues with audio using MinUI:

**L/R Channels are swapped.** This is due to `DAC Swap` being set to `On` on startup. No idea why this is the default - switching it `Off` in `InitSettings` is enough to resolve this.

**Random distortion/muffling,** especially at low volume. This is due to setting volume with `DAC Volume`. Using `digital volume` instead removes this issue. However, setting `digital volume` to it's minimum raw value (63) does not allow the device to mute. As a workaround, I also set `DAC Volume` to 0 if trying to mute.

Note: I tried `amixer sset 'digital volume' mute` and got `amixer: Invalid command!`. I'm not familiar with amixer - there's probably a better way to accomplish mute than also setting `DAC Volume`

**Poor volume curve.** Now that we're using `digital volume` we can use amixer's `-M` option and get a better volume curve. This wasn't possible when using `DAC Volume` because the range is not properly configured (i.e. 0dB is at 160 while it accepts values up to 255)

---

Tip: use headphones when testing. A good test track for these changes is [Green Hill Zone](https://www.youtube.com/watch?v=G-i8HYi1QH0) (Sonic 1 on Genesis, first level). The L/R channel flip is especially noticeable at 40 seconds. The distortion/muffling is noticeable throughout, especially if you set the volume to 1 before applying this patch

Thanks for creating MinUI!