### PR TITLE
Audio system completely rewritten in MinArch

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: Google
+BreakBeforeBraces: Attach
+IndentWidth: 4
+UseTab: Always
+TabWidth: 4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "*.tf": "terraform",
+        "*.in": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "*.tf": "terraform",
-        "*.in": "c"
-    }
-}

--- a/makefile
+++ b/makefile
@@ -148,7 +148,7 @@ package: tidy
 	rm -rf ./workspace/readmes
 	
 	cd ./build/SYSTEM && echo "$(RELEASE_NAME)\n$(BUILD_HASH)" > version.txt
-	./commits.sh > ./build/SYSTEM/commits.txt
+	# ./commits.sh > ./build/SYSTEM/commits.txt
 	cd ./build && find . -type f -name '.DS_Store' -delete
 	mkdir -p ./build/PAYLOAD
 	mv ./build/SYSTEM ./build/PAYLOAD/.system

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -1349,7 +1349,7 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
 		// Apply crossfade between the previous and current buffers
 		if (consumed > 0)
 		{
-			apply_crossfade(prev_buffer, resampled_frames, resampled_frame_count, 12);
+			apply_crossfade(prev_buffer, resampled_frames, resampled_frame_count, 64);
 		}
 
 		consumed_frames = 0;

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -1312,12 +1312,12 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
 	if (remaining_space < (snd.frame_count / 4))
 	{
 		// Decrease target_ratio to slow down the input rate if the buffer is filling up
-		target_ratio -= 0.000001;
+		target_ratio -= 0.000000001;
 	}
 	else if (remaining_space > (3 * snd.frame_count / 4))
 	{
 		// Increase target_ratio to speed up the input rate if the buffer has enough space
-		target_ratio += 0.000001;
+		target_ratio += 0.000000001;
 	}
 
 	// Smooth the target_ratio using a simple moving average

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -1291,7 +1291,7 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
 	if (snd.frame_count == 0)
 		return 0;
 
-	SDL_LockAudio();
+	// SDL_LockAudio();
 
 	int consumed = 0;
 	int consumed_frames = 0;
@@ -1351,7 +1351,7 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
 
 	free(resampled.frames);
 	// LOG_info("batch done unlock\n", frame_count);
-	SDL_UnlockAudio();
+	// SDL_UnlockAudio();
 	return consumed;
 }
 

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -17,16 +17,19 @@
 #include "defines.h"
 #include "api.h"
 #include "utils.h"
+#include <samplerate.h>
 
 ///////////////////////////////
 
-void LOG_note(int level, const char* fmt, ...) {
+void LOG_note(int level, const char *fmt, ...)
+{
 	char buf[1024] = {0};
 	va_list args;
 	va_start(args, fmt);
 	vsnprintf(buf, sizeof(buf), fmt, args);
 	va_end(args);
-	switch(level) {
+	switch (level)
+	{
 #ifdef DEBUG
 	case LOG_DEBUG:
 		printf("[DEBUG] %s", buf);
@@ -55,9 +58,10 @@ uint32_t RGB_LIGHT_GRAY;
 uint32_t RGB_GRAY;
 uint32_t RGB_DARK_GRAY;
 
-static struct GFX_Context {
-	SDL_Surface* screen;
-	SDL_Surface* assets;
+static struct GFX_Context
+{
+	SDL_Surface *screen;
+	SDL_Surface *assets;
 
 	int mode;
 	int vsync;
@@ -69,203 +73,230 @@ GFX_Fonts font;
 
 ///////////////////////////////
 
-static struct PWR_Context {
+static struct PWR_Context
+{
 	int initialized;
-	
+
 	int can_sleep;
 	int can_poweroff;
 	int can_autosleep;
 	int requested_sleep;
 	int requested_wake;
-	
+
 	pthread_t battery_pt;
 	int is_charging;
 	int charge;
 	int should_warn;
 
-	SDL_Surface* overlay;
+	SDL_Surface *overlay;
 } pwr = {0};
 
 ///////////////////////////////
 
 static int _;
 
-SDL_Surface* GFX_init(int mode) {
+SDL_Surface *GFX_init(int mode)
+{
 	// TODO: this doesn't really belong here...
 	// tried adding to PWR_init() but that was no good (not sure why)
 	PLAT_initLid();
-	
+
 	gfx.screen = PLAT_initVideo();
 	gfx.vsync = VSYNC_STRICT;
 	gfx.mode = mode;
-	
-	RGB_WHITE		= SDL_MapRGB(gfx.screen->format, TRIAD_WHITE);
-	RGB_BLACK		= SDL_MapRGB(gfx.screen->format, TRIAD_BLACK);
-	RGB_LIGHT_GRAY	= SDL_MapRGB(gfx.screen->format, TRIAD_LIGHT_GRAY);
-	RGB_GRAY		= SDL_MapRGB(gfx.screen->format, TRIAD_GRAY);
-	RGB_DARK_GRAY	= SDL_MapRGB(gfx.screen->format, TRIAD_DARK_GRAY);
-	
-	asset_rgbs[ASSET_WHITE_PILL]	= RGB_WHITE;
-	asset_rgbs[ASSET_BLACK_PILL]	= RGB_BLACK;
-	asset_rgbs[ASSET_DARK_GRAY_PILL]= RGB_DARK_GRAY;
-	asset_rgbs[ASSET_OPTION]		= RGB_DARK_GRAY;
-	asset_rgbs[ASSET_BUTTON]		= RGB_WHITE;
-	asset_rgbs[ASSET_PAGE_BG]		= RGB_WHITE;
-	asset_rgbs[ASSET_STATE_BG]		= RGB_WHITE;
-	asset_rgbs[ASSET_PAGE]			= RGB_BLACK;
-	asset_rgbs[ASSET_BAR]			= RGB_WHITE;
-	asset_rgbs[ASSET_BAR_BG]		= RGB_BLACK;
-	asset_rgbs[ASSET_BAR_BG_MENU]	= RGB_DARK_GRAY;
-	asset_rgbs[ASSET_UNDERLINE]		= RGB_GRAY;
-	asset_rgbs[ASSET_DOT]			= RGB_LIGHT_GRAY;
-	asset_rgbs[ASSET_HOLE]			= RGB_BLACK;
-	
-	asset_rects[ASSET_WHITE_PILL]		= (SDL_Rect){SCALE4( 1, 1,30,30)};
-	asset_rects[ASSET_BLACK_PILL]		= (SDL_Rect){SCALE4(33, 1,30,30)};
-	asset_rects[ASSET_DARK_GRAY_PILL]	= (SDL_Rect){SCALE4(65, 1,30,30)};
-	asset_rects[ASSET_OPTION]			= (SDL_Rect){SCALE4(97, 1,20,20)};
-	asset_rects[ASSET_BUTTON]			= (SDL_Rect){SCALE4( 1,33,20,20)};
-	asset_rects[ASSET_PAGE_BG]			= (SDL_Rect){SCALE4(64,33,15,15)};
-	asset_rects[ASSET_STATE_BG]			= (SDL_Rect){SCALE4(23,54, 8, 8)};
-	asset_rects[ASSET_PAGE]				= (SDL_Rect){SCALE4(39,54, 6, 6)};
-	asset_rects[ASSET_BAR]				= (SDL_Rect){SCALE4(33,58, 4, 4)};
-	asset_rects[ASSET_BAR_BG]			= (SDL_Rect){SCALE4(15,55, 4, 4)};
-	asset_rects[ASSET_BAR_BG_MENU]		= (SDL_Rect){SCALE4(85,56, 4, 4)};
-	asset_rects[ASSET_UNDERLINE]		= (SDL_Rect){SCALE4(85,51, 3, 3)};
-	asset_rects[ASSET_DOT]				= (SDL_Rect){SCALE4(33,54, 2, 2)};
-	asset_rects[ASSET_BRIGHTNESS]		= (SDL_Rect){SCALE4(23,33,19,19)};
-	asset_rects[ASSET_VOLUME_MUTE]		= (SDL_Rect){SCALE4(44,33,10,16)};
-	asset_rects[ASSET_VOLUME]			= (SDL_Rect){SCALE4(44,33,18,16)};
-	asset_rects[ASSET_BATTERY]			= (SDL_Rect){SCALE4(47,51,17,10)};
-	asset_rects[ASSET_BATTERY_LOW]		= (SDL_Rect){SCALE4(66,51,17,10)};
-	asset_rects[ASSET_BATTERY_FILL]		= (SDL_Rect){SCALE4(81,33,12, 6)};
-	asset_rects[ASSET_BATTERY_FILL_LOW]	= (SDL_Rect){SCALE4( 1,55,12, 6)};
-	asset_rects[ASSET_BATTERY_BOLT]		= (SDL_Rect){SCALE4(81,41,12, 6)};
-	asset_rects[ASSET_SCROLL_UP]		= (SDL_Rect){SCALE4(97,23,24, 6)};
-	asset_rects[ASSET_SCROLL_DOWN]		= (SDL_Rect){SCALE4(97,31,24, 6)};
-	asset_rects[ASSET_WIFI]				= (SDL_Rect){SCALE4(95,39,14,10)};
-	asset_rects[ASSET_HOLE]				= (SDL_Rect){SCALE4( 1,63,20,20)};
-	
+
+	RGB_WHITE = SDL_MapRGB(gfx.screen->format, TRIAD_WHITE);
+	RGB_BLACK = SDL_MapRGB(gfx.screen->format, TRIAD_BLACK);
+	RGB_LIGHT_GRAY = SDL_MapRGB(gfx.screen->format, TRIAD_LIGHT_GRAY);
+	RGB_GRAY = SDL_MapRGB(gfx.screen->format, TRIAD_GRAY);
+	RGB_DARK_GRAY = SDL_MapRGB(gfx.screen->format, TRIAD_DARK_GRAY);
+
+	asset_rgbs[ASSET_WHITE_PILL] = RGB_WHITE;
+	asset_rgbs[ASSET_BLACK_PILL] = RGB_BLACK;
+	asset_rgbs[ASSET_DARK_GRAY_PILL] = RGB_DARK_GRAY;
+	asset_rgbs[ASSET_OPTION] = RGB_DARK_GRAY;
+	asset_rgbs[ASSET_BUTTON] = RGB_WHITE;
+	asset_rgbs[ASSET_PAGE_BG] = RGB_WHITE;
+	asset_rgbs[ASSET_STATE_BG] = RGB_WHITE;
+	asset_rgbs[ASSET_PAGE] = RGB_BLACK;
+	asset_rgbs[ASSET_BAR] = RGB_WHITE;
+	asset_rgbs[ASSET_BAR_BG] = RGB_BLACK;
+	asset_rgbs[ASSET_BAR_BG_MENU] = RGB_DARK_GRAY;
+	asset_rgbs[ASSET_UNDERLINE] = RGB_GRAY;
+	asset_rgbs[ASSET_DOT] = RGB_LIGHT_GRAY;
+	asset_rgbs[ASSET_HOLE] = RGB_BLACK;
+
+	asset_rects[ASSET_WHITE_PILL] = (SDL_Rect){SCALE4(1, 1, 30, 30)};
+	asset_rects[ASSET_BLACK_PILL] = (SDL_Rect){SCALE4(33, 1, 30, 30)};
+	asset_rects[ASSET_DARK_GRAY_PILL] = (SDL_Rect){SCALE4(65, 1, 30, 30)};
+	asset_rects[ASSET_OPTION] = (SDL_Rect){SCALE4(97, 1, 20, 20)};
+	asset_rects[ASSET_BUTTON] = (SDL_Rect){SCALE4(1, 33, 20, 20)};
+	asset_rects[ASSET_PAGE_BG] = (SDL_Rect){SCALE4(64, 33, 15, 15)};
+	asset_rects[ASSET_STATE_BG] = (SDL_Rect){SCALE4(23, 54, 8, 8)};
+	asset_rects[ASSET_PAGE] = (SDL_Rect){SCALE4(39, 54, 6, 6)};
+	asset_rects[ASSET_BAR] = (SDL_Rect){SCALE4(33, 58, 4, 4)};
+	asset_rects[ASSET_BAR_BG] = (SDL_Rect){SCALE4(15, 55, 4, 4)};
+	asset_rects[ASSET_BAR_BG_MENU] = (SDL_Rect){SCALE4(85, 56, 4, 4)};
+	asset_rects[ASSET_UNDERLINE] = (SDL_Rect){SCALE4(85, 51, 3, 3)};
+	asset_rects[ASSET_DOT] = (SDL_Rect){SCALE4(33, 54, 2, 2)};
+	asset_rects[ASSET_BRIGHTNESS] = (SDL_Rect){SCALE4(23, 33, 19, 19)};
+	asset_rects[ASSET_VOLUME_MUTE] = (SDL_Rect){SCALE4(44, 33, 10, 16)};
+	asset_rects[ASSET_VOLUME] = (SDL_Rect){SCALE4(44, 33, 18, 16)};
+	asset_rects[ASSET_BATTERY] = (SDL_Rect){SCALE4(47, 51, 17, 10)};
+	asset_rects[ASSET_BATTERY_LOW] = (SDL_Rect){SCALE4(66, 51, 17, 10)};
+	asset_rects[ASSET_BATTERY_FILL] = (SDL_Rect){SCALE4(81, 33, 12, 6)};
+	asset_rects[ASSET_BATTERY_FILL_LOW] = (SDL_Rect){SCALE4(1, 55, 12, 6)};
+	asset_rects[ASSET_BATTERY_BOLT] = (SDL_Rect){SCALE4(81, 41, 12, 6)};
+	asset_rects[ASSET_SCROLL_UP] = (SDL_Rect){SCALE4(97, 23, 24, 6)};
+	asset_rects[ASSET_SCROLL_DOWN] = (SDL_Rect){SCALE4(97, 31, 24, 6)};
+	asset_rects[ASSET_WIFI] = (SDL_Rect){SCALE4(95, 39, 14, 10)};
+	asset_rects[ASSET_HOLE] = (SDL_Rect){SCALE4(1, 63, 20, 20)};
+
 	char asset_path[MAX_PATH];
 	sprintf(asset_path, RES_PATH "/assets@%ix.png", FIXED_SCALE);
-	if (!exists(asset_path)) LOG_info("missing assets, you're about to segfault dummy!\n");
+	if (!exists(asset_path))
+		LOG_info("missing assets, you're about to segfault dummy!\n");
 	gfx.assets = IMG_Load(asset_path);
-	
+
 	TTF_Init();
-	font.large 	= TTF_OpenFont(FONT_PATH, SCALE1(FONT_LARGE));
+	font.large = TTF_OpenFont(FONT_PATH, SCALE1(FONT_LARGE));
 	font.medium = TTF_OpenFont(FONT_PATH, SCALE1(FONT_MEDIUM));
-	font.small 	= TTF_OpenFont(FONT_PATH, SCALE1(FONT_SMALL));
-	font.tiny 	= TTF_OpenFont(FONT_PATH, SCALE1(FONT_TINY));
-	
+	font.small = TTF_OpenFont(FONT_PATH, SCALE1(FONT_SMALL));
+	font.tiny = TTF_OpenFont(FONT_PATH, SCALE1(FONT_TINY));
+
 	TTF_SetFontStyle(font.large, TTF_STYLE_BOLD);
 	TTF_SetFontStyle(font.medium, TTF_STYLE_BOLD);
 	TTF_SetFontStyle(font.small, TTF_STYLE_BOLD);
 	TTF_SetFontStyle(font.tiny, TTF_STYLE_BOLD);
-	
+
 	return gfx.screen;
 }
-void GFX_quit(void) {
+void GFX_quit(void)
+{
 	TTF_CloseFont(font.large);
 	TTF_CloseFont(font.medium);
 	TTF_CloseFont(font.small);
 	TTF_CloseFont(font.tiny);
-	
+
 	SDL_FreeSurface(gfx.assets);
-	
+
 	GFX_freeAAScaler();
-	
+
 	GFX_clearAll();
 
 	PLAT_quitVideo();
 }
 
-void GFX_setMode(int mode) {
+void GFX_setMode(int mode)
+{
 	gfx.mode = mode;
 }
-int GFX_getVsync(void) {
+int GFX_getVsync(void)
+{
 	return gfx.vsync;
 }
-void GFX_setVsync(int vsync) {
+void GFX_setVsync(int vsync)
+{
 	PLAT_setVsync(vsync);
 	gfx.vsync = vsync;
 }
 
-int GFX_hdmiChanged(void) {
+int GFX_hdmiChanged(void)
+{
 	static int had_hdmi = -1;
 	int has_hdmi = GetHDMI();
-	if (had_hdmi==-1) had_hdmi = has_hdmi;
-	if (had_hdmi==has_hdmi) return 0;
+	if (had_hdmi == -1)
+		had_hdmi = has_hdmi;
+	if (had_hdmi == has_hdmi)
+		return 0;
 	had_hdmi = has_hdmi;
 	return 1;
 }
 
 #define FRAME_BUDGET 17 // 60fps
 static uint32_t frame_start = 0;
-void GFX_startFrame(void) {
+void GFX_startFrame(void)
+{
 	frame_start = SDL_GetTicks();
 }
 
-void GFX_flip(SDL_Surface* screen) {
-	int should_vsync = (gfx.vsync!=VSYNC_OFF && (gfx.vsync==VSYNC_STRICT || frame_start==0 || SDL_GetTicks()-frame_start<FRAME_BUDGET));
+void GFX_flip(SDL_Surface *screen)
+{
+	int should_vsync = (gfx.vsync != VSYNC_OFF && (gfx.vsync == VSYNC_STRICT || frame_start == 0 || SDL_GetTicks() - frame_start < FRAME_BUDGET));
 	PLAT_flip(screen, should_vsync);
 }
-void GFX_sync(void) {
+void GFX_sync(void)
+{
 	uint32_t frame_duration = SDL_GetTicks() - frame_start;
-	if (gfx.vsync!=VSYNC_OFF) {
+	if (gfx.vsync != VSYNC_OFF)
+	{
 		// this limiting condition helps SuperFX chip games
-		if (gfx.vsync==VSYNC_STRICT || frame_start==0 || frame_duration<FRAME_BUDGET) { // only wait if we're under frame budget
-			PLAT_vsync(FRAME_BUDGET-frame_duration);
+		if (gfx.vsync == VSYNC_STRICT || frame_start == 0 || frame_duration < FRAME_BUDGET)
+		{ // only wait if we're under frame budget
+			PLAT_vsync(FRAME_BUDGET - frame_duration);
 		}
 	}
-	else {
-		if (frame_duration<FRAME_BUDGET) SDL_Delay(FRAME_BUDGET-frame_duration);
+	else
+	{
+		if (frame_duration < FRAME_BUDGET)
+			SDL_Delay(FRAME_BUDGET - frame_duration);
 	}
 }
 
 FALLBACK_IMPLEMENTATION int PLAT_supportsOverscan(void) { return 0; }
-FALLBACK_IMPLEMENTATION void PLAT_setEffectColor(int next_color) { }
+FALLBACK_IMPLEMENTATION void PLAT_setEffectColor(int next_color) {}
 
-int GFX_truncateText(TTF_Font* font, const char* in_name, char* out_name, int max_width, int padding) {
+int GFX_truncateText(TTF_Font *font, const char *in_name, char *out_name, int max_width, int padding)
+{
 	int text_width;
 	strcpy(out_name, in_name);
 	TTF_SizeUTF8(font, out_name, &text_width, NULL);
 	text_width += padding;
-	
-	while (text_width>max_width) {
+
+	while (text_width > max_width)
+	{
 		int len = strlen(out_name);
-		strcpy(&out_name[len-4], "...\0");
+		strcpy(&out_name[len - 4], "...\0");
 		TTF_SizeUTF8(font, out_name, &text_width, NULL);
 		text_width += padding;
 	}
-	
+
 	return text_width;
 }
-int GFX_wrapText(TTF_Font* font, char* str, int max_width, int max_lines) {
-	if (!str) return 0;
-	
+int GFX_wrapText(TTF_Font *font, char *str, int max_width, int max_lines)
+{
+	if (!str)
+		return 0;
+
 	int line_width;
 	int max_line_width = 0;
-	char* line = str;
+	char *line = str;
 	char buffer[MAX_PATH];
-	
+
 	TTF_SizeUTF8(font, line, &line_width, NULL);
-	if (line_width<=max_width) {
-		line_width = GFX_truncateText(font,line,buffer,max_width,0);
-		strcpy(line,buffer);
+	if (line_width <= max_width)
+	{
+		line_width = GFX_truncateText(font, line, buffer, max_width, 0);
+		strcpy(line, buffer);
 		return line_width;
 	}
-	
-	char* prev = NULL;
-	char* tmp = line;
+
+	char *prev = NULL;
+	char *tmp = line;
 	int lines = 1;
 	int i = 0;
-	while (!max_lines || lines<max_lines) {
+	while (!max_lines || lines < max_lines)
+	{
 		tmp = strchr(tmp, ' ');
-		if (!tmp) {
-			if (prev) {
+		if (!tmp)
+		{
+			if (prev)
+			{
 				TTF_SizeUTF8(font, line, &line_width, NULL);
-				if (line_width>=max_width) {
-					if (line_width>max_line_width) max_line_width = line_width;
+				if (line_width >= max_width)
+				{
+					if (line_width > max_line_width)
+						max_line_width = line_width;
 					prev[0] = '\n';
 					line = prev + 1;
 				}
@@ -273,11 +304,13 @@ int GFX_wrapText(TTF_Font* font, char* str, int max_width, int max_lines) {
 			break;
 		}
 		tmp[0] = '\0';
-		
+
 		TTF_SizeUTF8(font, line, &line_width, NULL);
 
-		if (line_width>=max_width) { // wrap
-			if (line_width>max_line_width) max_line_width = line_width;
+		if (line_width >= max_width)
+		{ // wrap
+			if (line_width > max_line_width)
+				max_line_width = line_width;
 			tmp[0] = ' ';
 			tmp += 1;
 			prev[0] = '\n';
@@ -285,18 +318,20 @@ int GFX_wrapText(TTF_Font* font, char* str, int max_width, int max_lines) {
 			line = prev;
 			lines += 1;
 		}
-		else { // continue
+		else
+		{ // continue
 			tmp[0] = ' ';
 			prev = tmp;
 			tmp += 1;
 		}
 		i += 1;
 	}
-	
-	line_width = GFX_truncateText(font,line,buffer,max_width,0);
-	strcpy(line,buffer);
-	
-	if (line_width>max_line_width) max_line_width = line_width;
+
+	line_width = GFX_truncateText(font, line, buffer, max_width, 0);
+	strcpy(line, buffer);
+
+	if (line_width > max_line_width)
+		max_line_width = line_width;
 	return max_line_width;
 }
 
@@ -304,7 +339,8 @@ int GFX_wrapText(TTF_Font* font, char* str, int max_width, int max_lines) {
 
 // scale_blend (and supporting logic) from picoarch
 
-struct blend_args {
+struct blend_args
+{
 	int w_ratio_in;
 	int w_ratio_out;
 	uint16_t w_bp[2];
@@ -315,28 +351,30 @@ struct blend_args {
 } blend_args;
 
 #if __ARM_ARCH >= 5
-static inline uint32_t average16(uint32_t c1, uint32_t c2) {
+static inline uint32_t average16(uint32_t c1, uint32_t c2)
+{
 	uint32_t ret, lowbits = 0x0821;
-	asm ("eor %0, %2, %3\r\n"
-	     "and %0, %0, %1\r\n"
-	     "add %0, %3, %0\r\n"
-	     "add %0, %0, %2\r\n"
-	     "lsr %0, %0, #1\r\n"
-	     : "=&r" (ret) : "r" (lowbits), "r" (c1), "r" (c2) : );
+	asm("eor %0, %2, %3\r\n"
+		"and %0, %0, %1\r\n"
+		"add %0, %3, %0\r\n"
+		"add %0, %0, %2\r\n"
+		"lsr %0, %0, #1\r\n"
+		: "=&r"(ret) : "r"(lowbits), "r"(c1), "r"(c2) :);
 	return ret;
 }
-static inline uint32_t average32(uint32_t c1, uint32_t c2) {
+static inline uint32_t average32(uint32_t c1, uint32_t c2)
+{
 	uint32_t ret, lowbits = 0x08210821;
 
-	asm ("eor %0, %3, %1\r\n"
-	     "and %0, %0, %2\r\n"
-	     "adds %0, %1, %0\r\n"
-	     "and %1, %1, #0\r\n"
-	     "movcs %1, #0x80000000\r\n"
-	     "adds %0, %0, %3\r\n"
-	     "rrx %0, %0\r\n"
-	     "orr %0, %0, %1\r\n"
-	     : "=&r" (ret), "+r" (c2) : "r" (lowbits), "r" (c1) : "cc" );
+	asm("eor %0, %3, %1\r\n"
+		"and %0, %0, %2\r\n"
+		"adds %0, %1, %0\r\n"
+		"and %1, %1, #0\r\n"
+		"movcs %1, #0x80000000\r\n"
+		"adds %0, %0, %3\r\n"
+		"rrx %0, %0\r\n"
+		"orr %0, %0, %1\r\n"
+		: "=&r"(ret), "+r"(c2) : "r"(lowbits), "r"(c1) : "cc");
 
 	return ret;
 }
@@ -346,10 +384,12 @@ static inline uint32_t average32(uint32_t c1, uint32_t c2) {
 
 #else
 
-static inline uint32_t average16(uint32_t c1, uint32_t c2) {
-	return (c1 + c2 + ((c1 ^ c2) & 0x0821))>>1;
+static inline uint32_t average16(uint32_t c1, uint32_t c2)
+{
+	return (c1 + c2 + ((c1 ^ c2) & 0x0821)) >> 1;
 }
-static inline uint32_t average32(uint32_t c1, uint32_t c2) {
+static inline uint32_t average32(uint32_t c1, uint32_t c2)
+{
 	uint32_t sum = c1 + c2;
 	uint32_t ret = sum + ((c1 ^ c2) & 0x08210821);
 	uint32_t of = ((sum < c1) | (ret < sum)) << 31;
@@ -368,11 +408,13 @@ static inline uint32_t average32(uint32_t c1, uint32_t c2) {
 #define AVERAGE32(c1, c2) ((c1) == (c2) ? (c1) : AVERAGE32_NOCHK((c1), (c2)))
 #define AVERAGE32_1_3(c1, c2) ((c1) == (c2) ? (c1) : (AVERAGE32_NOCHK(AVERAGE32_NOCHK((c1), (c2)), (c2))))
 
-static inline int gcd(int a, int b) {
+static inline int gcd(int a, int b)
+{
 	return b ? gcd(b, a % b) : a;
 }
 
-static void scaleAA(void* __restrict src, void* __restrict dst, uint32_t w, uint32_t h, uint32_t pitch, uint32_t dst_w, uint32_t dst_h, uint32_t dst_p) {
+static void scaleAA(void *__restrict src, void *__restrict dst, uint32_t w, uint32_t h, uint32_t pitch, uint32_t dst_w, uint32_t dst_h, uint32_t dst_p)
+{
 	int dy = 0;
 	int lines = h;
 
@@ -384,8 +426,10 @@ static void scaleAA(void* __restrict src, void* __restrict dst, uint32_t w, uint
 	int rat_dst_h = blend_args.h_ratio_out;
 	uint16_t *bh = blend_args.h_bp;
 
-	while (lines--) {
-		while (dy < rat_dst_h) {
+	while (lines--)
+	{
+		while (dy < rat_dst_h)
+		{
 			uint16_t *dst16 = (uint16_t *)dst;
 			uint16_t *pblend = (uint16_t *)blend_args.blend_line;
 			int col = w;
@@ -395,31 +439,42 @@ static void scaleAA(void* __restrict src, void* __restrict dst, uint32_t w, uint
 			if (!lines)
 				pnext -= (pitch / sizeof(uint16_t));
 
-			if (dy > rat_dst_h - bh[0]) {
+			if (dy > rat_dst_h - bh[0])
+			{
 				pblend = pnext;
-			} else if (dy <= bh[0]) {
+			}
+			else if (dy <= bh[0])
+			{
 				/* Drops const, won't get touched later though */
 				pblend = (uint16_t *)src;
-			} else {
+			}
+			else
+			{
 				const uint32_t *src32 = (const uint32_t *)src;
 				const uint32_t *pnext32 = (const uint32_t *)pnext;
 				uint32_t *pblend32 = (uint32_t *)pblend;
 				int count = w / 2;
 
-				if (dy <= bh[1]) {
+				if (dy <= bh[1])
+				{
 					const uint32_t *tmp = pnext32;
 					pnext32 = src32;
 					src32 = tmp;
 				}
 
-				if (dy > rat_dst_h - bh[1] || dy <= bh[1]) {
-					while(count--) {
+				if (dy > rat_dst_h - bh[1] || dy <= bh[1])
+				{
+					while (count--)
+					{
 						*pblend32++ = AVERAGE32_1_3(*src32, *pnext32);
 						src32++;
 						pnext32++;
 					}
-				} else {
-					while(count--) {
+				}
+				else
+				{
+					while (count--)
+					{
 						*pblend32++ = AVERAGE32(*src32, *pnext32);
 						src32++;
 						pnext32++;
@@ -427,24 +482,36 @@ static void scaleAA(void* __restrict src, void* __restrict dst, uint32_t w, uint
 				}
 			}
 
-			while (col--) {
+			while (col--)
+			{
 				uint16_t a, b, out;
 
 				a = *pblend;
-				b = *(pblend+1);
+				b = *(pblend + 1);
 
-				while (dx < rat_dst_w) {
-					if (a == b) {
+				while (dx < rat_dst_w)
+				{
+					if (a == b)
+					{
 						out = a;
-					} else if (dx > rat_dst_w - bw[0]) { // top quintile, bbbb
+					}
+					else if (dx > rat_dst_w - bw[0])
+					{ // top quintile, bbbb
 						out = b;
-					} else if (dx <= bw[0]) { // last quintile, aaaa
+					}
+					else if (dx <= bw[0])
+					{ // last quintile, aaaa
 						out = a;
-					} else {
-						if (dx > rat_dst_w - bw[1]) { // 2nd quintile, abbb
-							a = AVERAGE16_NOCHK(a,b);
-						} else if (dx <= bw[1]) { // 4th quintile, aaab
-							b = AVERAGE16_NOCHK(a,b);
+					}
+					else
+					{
+						if (dx > rat_dst_w - bw[1])
+						{ // 2nd quintile, abbb
+							a = AVERAGE16_NOCHK(a, b);
+						}
+						else if (dx <= bw[1])
+						{ // 4th quintile, aaab
+							b = AVERAGE16_NOCHK(a, b);
 						}
 
 						out = AVERAGE16_NOCHK(a, b); // also 3rd quintile, aabb
@@ -466,18 +533,19 @@ static void scaleAA(void* __restrict src, void* __restrict dst, uint32_t w, uint
 	}
 }
 
-scaler_t GFX_getAAScaler(GFX_Renderer* renderer) {
+scaler_t GFX_getAAScaler(GFX_Renderer *renderer)
+{
 	int gcd_w, div_w, gcd_h, div_h;
 	blend_args.blend_line = calloc(renderer->src_w, sizeof(uint16_t));
 
 	gcd_w = gcd(renderer->src_w, renderer->dst_w);
 	blend_args.w_ratio_in = renderer->src_w / gcd_w;
 	blend_args.w_ratio_out = renderer->dst_w / gcd_w;
-	
-	double blend_denominator = (renderer->src_w>renderer->dst_w) ? 5 : 2.5; // TODO: these values are really only good for the nano...
+
+	double blend_denominator = (renderer->src_w > renderer->dst_w) ? 5 : 2.5; // TODO: these values are really only good for the nano...
 	// blend_denominator = 5.0; // better for trimui
 	// LOG_info("blend_denominator: %f (%i && %i)\n", blend_denominator, HAS_SKINNY_SCREEN, renderer->dst_w>renderer->src_w);
-	
+
 	div_w = round(blend_args.w_ratio_out / blend_denominator);
 	blend_args.w_bp[0] = div_w;
 	blend_args.w_bp[1] = blend_args.w_ratio_out >> 1;
@@ -489,11 +557,13 @@ scaler_t GFX_getAAScaler(GFX_Renderer* renderer) {
 	div_h = round(blend_args.h_ratio_out / blend_denominator);
 	blend_args.h_bp[0] = div_h;
 	blend_args.h_bp[1] = blend_args.h_ratio_out >> 1;
-	
+
 	return scaleAA;
 }
-void GFX_freeAAScaler(void) {
-	if (blend_args.blend_line != NULL) {
+void GFX_freeAAScaler(void)
+{
+	if (blend_args.blend_line != NULL)
+	{
 		free(blend_args.blend_line);
 		blend_args.blend_line = NULL;
 	}
@@ -501,314 +571,339 @@ void GFX_freeAAScaler(void) {
 
 ///////////////////////////////
 
-void GFX_blitAsset(int asset, SDL_Rect* src_rect, SDL_Surface* dst, SDL_Rect* dst_rect) {
-	SDL_Rect* rect = &asset_rects[asset];
+void GFX_blitAsset(int asset, SDL_Rect *src_rect, SDL_Surface *dst, SDL_Rect *dst_rect)
+{
+	SDL_Rect *rect = &asset_rects[asset];
 	SDL_Rect adj_rect = {
 		.x = rect->x,
 		.y = rect->y,
 		.w = rect->w,
 		.h = rect->h,
 	};
-	if (src_rect) {
+	if (src_rect)
+	{
 		adj_rect.x += src_rect->x;
 		adj_rect.y += src_rect->y;
-		adj_rect.w  = src_rect->w;
-		adj_rect.h  = src_rect->h;
+		adj_rect.w = src_rect->w;
+		adj_rect.h = src_rect->h;
 	}
 	SDL_BlitSurface(gfx.assets, &adj_rect, dst, dst_rect);
 }
-void GFX_blitPill(int asset, SDL_Surface* dst, SDL_Rect* dst_rect) {
+void GFX_blitPill(int asset, SDL_Surface *dst, SDL_Rect *dst_rect)
+{
 	int x = dst_rect->x;
 	int y = dst_rect->y;
 	int w = dst_rect->w;
 	int h = dst_rect->h;
 
-	if (h==0) h = asset_rects[asset].h;
-	
+	if (h == 0)
+		h = asset_rects[asset].h;
+
 	int r = h / 2;
-	if (w < h) w = h;
+	if (w < h)
+		w = h;
 	w -= h;
-	
-	GFX_blitAsset(asset, &(SDL_Rect){0,0,r,h}, dst, &(SDL_Rect){x,y});
+
+	GFX_blitAsset(asset, &(SDL_Rect){0, 0, r, h}, dst, &(SDL_Rect){x, y});
 	x += r;
-	if (w>0) {
-		SDL_FillRect(dst, &(SDL_Rect){x,y,w,h}, asset_rgbs[asset]);
+	if (w > 0)
+	{
+		SDL_FillRect(dst, &(SDL_Rect){x, y, w, h}, asset_rgbs[asset]);
 		x += w;
 	}
-	GFX_blitAsset(asset, &(SDL_Rect){r,0,r,h}, dst, &(SDL_Rect){x,y});
+	GFX_blitAsset(asset, &(SDL_Rect){r, 0, r, h}, dst, &(SDL_Rect){x, y});
 }
-void GFX_blitRect(int asset, SDL_Surface* dst, SDL_Rect* dst_rect) {
+void GFX_blitRect(int asset, SDL_Surface *dst, SDL_Rect *dst_rect)
+{
 	int x = dst_rect->x;
 	int y = dst_rect->y;
 	int w = dst_rect->w;
 	int h = dst_rect->h;
 	int c = asset_rgbs[asset];
-	
-	SDL_Rect* rect = &asset_rects[asset];
+
+	SDL_Rect *rect = &asset_rects[asset];
 	int d = rect->w;
 	int r = d / 2;
 
-	GFX_blitAsset(asset, &(SDL_Rect){0,0,r,r}, dst, &(SDL_Rect){x,y});
-	SDL_FillRect(dst, &(SDL_Rect){x+r,y,w-d,r}, c);
-	GFX_blitAsset(asset, &(SDL_Rect){r,0,r,r}, dst, &(SDL_Rect){x+w-r,y});
-	SDL_FillRect(dst, &(SDL_Rect){x,y+r,w,h-d}, c);
-	GFX_blitAsset(asset, &(SDL_Rect){0,r,r,r}, dst, &(SDL_Rect){x,y+h-r});
-	SDL_FillRect(dst, &(SDL_Rect){x+r,y+h-r,w-d,r}, c);
-	GFX_blitAsset(asset, &(SDL_Rect){r,r,r,r}, dst, &(SDL_Rect){x+w-r,y+h-r});
+	GFX_blitAsset(asset, &(SDL_Rect){0, 0, r, r}, dst, &(SDL_Rect){x, y});
+	SDL_FillRect(dst, &(SDL_Rect){x + r, y, w - d, r}, c);
+	GFX_blitAsset(asset, &(SDL_Rect){r, 0, r, r}, dst, &(SDL_Rect){x + w - r, y});
+	SDL_FillRect(dst, &(SDL_Rect){x, y + r, w, h - d}, c);
+	GFX_blitAsset(asset, &(SDL_Rect){0, r, r, r}, dst, &(SDL_Rect){x, y + h - r});
+	SDL_FillRect(dst, &(SDL_Rect){x + r, y + h - r, w - d, r}, c);
+	GFX_blitAsset(asset, &(SDL_Rect){r, r, r, r}, dst, &(SDL_Rect){x + w - r, y + h - r});
 }
-void GFX_blitBattery(SDL_Surface* dst, SDL_Rect* dst_rect) {
+void GFX_blitBattery(SDL_Surface *dst, SDL_Rect *dst_rect)
+{
 	// LOG_info("dst: %p\n", dst);
 	int x = 0;
 	int y = 0;
-	if (dst_rect) {
+	if (dst_rect)
+	{
 		x = dst_rect->x;
 		y = dst_rect->y;
 	}
 	SDL_Rect rect = asset_rects[ASSET_BATTERY];
 	x += (SCALE1(PILL_SIZE) - (rect.w + FIXED_SCALE)) / 2;
 	y += (SCALE1(PILL_SIZE) - rect.h) / 2;
-	
-	if (pwr.is_charging) {
-		GFX_blitAsset(ASSET_BATTERY, NULL, dst, &(SDL_Rect){x,y});
-		GFX_blitAsset(ASSET_BATTERY_BOLT, NULL, dst, &(SDL_Rect){x+SCALE1(3),y+SCALE1(2)});
+
+	if (pwr.is_charging)
+	{
+		GFX_blitAsset(ASSET_BATTERY, NULL, dst, &(SDL_Rect){x, y});
+		GFX_blitAsset(ASSET_BATTERY_BOLT, NULL, dst, &(SDL_Rect){x + SCALE1(3), y + SCALE1(2)});
 	}
-	else {
+	else
+	{
 		int percent = pwr.charge;
-		GFX_blitAsset(percent<=10?ASSET_BATTERY_LOW:ASSET_BATTERY, NULL, dst, &(SDL_Rect){x,y});
-		
+		GFX_blitAsset(percent <= 10 ? ASSET_BATTERY_LOW : ASSET_BATTERY, NULL, dst, &(SDL_Rect){x, y});
+
 		rect = asset_rects[ASSET_BATTERY_FILL];
 		SDL_Rect clip = rect;
 		clip.w *= percent;
 		clip.w /= 100;
-		if (clip.w<=0) return;
+		if (clip.w <= 0)
+			return;
 		clip.x = rect.w - clip.w;
 		clip.y = 0;
-		
-		GFX_blitAsset(percent<=20?ASSET_BATTERY_FILL_LOW:ASSET_BATTERY_FILL, &clip, dst, &(SDL_Rect){x+SCALE1(3)+clip.x,y+SCALE1(2)});
+
+		GFX_blitAsset(percent <= 20 ? ASSET_BATTERY_FILL_LOW : ASSET_BATTERY_FILL, &clip, dst, &(SDL_Rect){x + SCALE1(3) + clip.x, y + SCALE1(2)});
 	}
 }
-int GFX_getButtonWidth(char* hint, char* button) {
+int GFX_getButtonWidth(char *hint, char *button)
+{
 	int button_width = 0;
 	int width;
-	
-	int special_case = !strcmp(button,BRIGHTNESS_BUTTON_LABEL); // TODO: oof
-	
-	if (strlen(button)==1) {
+
+	int special_case = !strcmp(button, BRIGHTNESS_BUTTON_LABEL); // TODO: oof
+
+	if (strlen(button) == 1)
+	{
 		button_width += SCALE1(BUTTON_SIZE);
 	}
-	else {
+	else
+	{
 		button_width += SCALE1(BUTTON_SIZE) / 2;
 		TTF_SizeUTF8(special_case ? font.large : font.tiny, button, &width, NULL);
 		button_width += width;
 	}
 	button_width += SCALE1(BUTTON_MARGIN);
-	
+
 	TTF_SizeUTF8(font.small, hint, &width, NULL);
 	button_width += width + SCALE1(BUTTON_MARGIN);
 	return button_width;
 }
-void GFX_blitButton(char* hint, char*button, SDL_Surface* dst, SDL_Rect* dst_rect) {
-	SDL_Surface* text;
+void GFX_blitButton(char *hint, char *button, SDL_Surface *dst, SDL_Rect *dst_rect)
+{
+	SDL_Surface *text;
 	int ox = 0;
-	
-	int special_case = !strcmp(button,BRIGHTNESS_BUTTON_LABEL); // TODO: oof
-	
+
+	int special_case = !strcmp(button, BRIGHTNESS_BUTTON_LABEL); // TODO: oof
+
 	// button
-	if (strlen(button)==1) {
+	if (strlen(button) == 1)
+	{
 		GFX_blitAsset(ASSET_BUTTON, NULL, dst, dst_rect);
 
 		// label
 		text = TTF_RenderUTF8_Blended(font.medium, button, COLOR_BUTTON_TEXT);
-		SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){dst_rect->x+(SCALE1(BUTTON_SIZE)-text->w)/2,dst_rect->y+(SCALE1(BUTTON_SIZE)-text->h)/2});
+		SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){dst_rect->x + (SCALE1(BUTTON_SIZE) - text->w) / 2, dst_rect->y + (SCALE1(BUTTON_SIZE) - text->h) / 2});
 		ox += SCALE1(BUTTON_SIZE);
 		SDL_FreeSurface(text);
 	}
-	else {
+	else
+	{
 		text = TTF_RenderUTF8_Blended(special_case ? font.large : font.tiny, button, COLOR_BUTTON_TEXT);
-		GFX_blitPill(ASSET_BUTTON, dst, &(SDL_Rect){dst_rect->x,dst_rect->y,SCALE1(BUTTON_SIZE)/2+text->w,SCALE1(BUTTON_SIZE)});
-		ox += SCALE1(BUTTON_SIZE)/4;
-		
+		GFX_blitPill(ASSET_BUTTON, dst, &(SDL_Rect){dst_rect->x, dst_rect->y, SCALE1(BUTTON_SIZE) / 2 + text->w, SCALE1(BUTTON_SIZE)});
+		ox += SCALE1(BUTTON_SIZE) / 4;
+
 		int oy = special_case ? SCALE1(-2) : 0;
-		SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){ox+dst_rect->x,oy+dst_rect->y+(SCALE1(BUTTON_SIZE)-text->h)/2,text->w,text->h});
+		SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){ox + dst_rect->x, oy + dst_rect->y + (SCALE1(BUTTON_SIZE) - text->h) / 2, text->w, text->h});
 		ox += text->w;
-		ox += SCALE1(BUTTON_SIZE)/4;
+		ox += SCALE1(BUTTON_SIZE) / 4;
 		SDL_FreeSurface(text);
 	}
-	
+
 	ox += SCALE1(BUTTON_MARGIN);
 
 	// hint text
 	text = TTF_RenderUTF8_Blended(font.small, hint, COLOR_WHITE);
-	SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){ox+dst_rect->x,dst_rect->y+(SCALE1(BUTTON_SIZE)-text->h)/2,text->w,text->h});
+	SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){ox + dst_rect->x, dst_rect->y + (SCALE1(BUTTON_SIZE) - text->h) / 2, text->w, text->h});
 	SDL_FreeSurface(text);
 }
-void GFX_blitMessage(TTF_Font* font, char* msg, SDL_Surface* dst, SDL_Rect* dst_rect) {
-	if (!dst_rect) dst_rect = &(SDL_Rect){0,0,dst->w,dst->h};
-	
+void GFX_blitMessage(TTF_Font *font, char *msg, SDL_Surface *dst, SDL_Rect *dst_rect)
+{
+	if (!dst_rect)
+		dst_rect = &(SDL_Rect){0, 0, dst->w, dst->h};
+
 	// LOG_info("GFX_blitMessage: %p (%ix%i)", dst, dst_rect->w,dst_rect->h);
-	
-	SDL_Surface* text;
+
+	SDL_Surface *text;
 #define TEXT_BOX_MAX_ROWS 16
 #define LINE_HEIGHT 24
-	char* rows[TEXT_BOX_MAX_ROWS];
+	char *rows[TEXT_BOX_MAX_ROWS];
 	int row_count = 0;
 
-	char* tmp;
+	char *tmp;
 	rows[row_count++] = msg;
-	while ((tmp=strchr(rows[row_count-1], '\n'))!=NULL) {
-		if (row_count+1>=TEXT_BOX_MAX_ROWS) return; // TODO: bail
-		rows[row_count++] = tmp+1;
+	while ((tmp = strchr(rows[row_count - 1], '\n')) != NULL)
+	{
+		if (row_count + 1 >= TEXT_BOX_MAX_ROWS)
+			return; // TODO: bail
+		rows[row_count++] = tmp + 1;
 	}
-	
+
 	int rendered_height = SCALE1(LINE_HEIGHT) * row_count;
 	int y = dst_rect->y;
 	y += (dst_rect->h - rendered_height) / 2;
-	
+
 	char line[256];
-	for (int i=0; i<row_count; i++) {
+	for (int i = 0; i < row_count; i++)
+	{
 		int len;
-		if (i+1<row_count) {
-			len = rows[i+1]-rows[i]-1;
-			if (len) strncpy(line, rows[i], len);
+		if (i + 1 < row_count)
+		{
+			len = rows[i + 1] - rows[i] - 1;
+			if (len)
+				strncpy(line, rows[i], len);
 			line[len] = '\0';
 		}
-		else {
+		else
+		{
 			len = strlen(rows[i]);
 			strcpy(line, rows[i]);
 		}
-		
-		
-		if (len) {
+
+		if (len)
+		{
 			text = TTF_RenderUTF8_Blended(font, line, COLOR_WHITE);
 			int x = dst_rect->x;
 			x += (dst_rect->w - text->w) / 2;
-			SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){x,y});
+			SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){x, y});
 			SDL_FreeSurface(text);
 		}
 		y += SCALE1(LINE_HEIGHT);
 	}
 }
 
-int GFX_blitHardwareGroup(SDL_Surface* dst, int show_setting) {
+int GFX_blitHardwareGroup(SDL_Surface *dst, int show_setting)
+{
 	int ox;
 	int oy;
 	int ow = 0;
-	
+
 	int setting_value;
 	int setting_min;
 	int setting_max;
-	
-	if (show_setting && !GetHDMI()) {
+
+	if (show_setting && !GetHDMI())
+	{
 		ow = SCALE1(PILL_SIZE + SETTINGS_WIDTH + 10 + 4);
 		ox = dst->w - SCALE1(PADDING) - ow;
 		oy = SCALE1(PADDING);
-		GFX_blitPill(gfx.mode==MODE_MAIN ? ASSET_DARK_GRAY_PILL : ASSET_BLACK_PILL, dst, &(SDL_Rect){
-			ox,
-			oy,
-			ow,
-			SCALE1(PILL_SIZE)
-		});
-		
-		if (show_setting==1) {
+		GFX_blitPill(gfx.mode == MODE_MAIN ? ASSET_DARK_GRAY_PILL : ASSET_BLACK_PILL, dst, &(SDL_Rect){ox, oy, ow, SCALE1(PILL_SIZE)});
+
+		if (show_setting == 1)
+		{
 			setting_value = GetBrightness();
 			setting_min = BRIGHTNESS_MIN;
 			setting_max = BRIGHTNESS_MAX;
 		}
-		else {
+		else
+		{
 			setting_value = GetVolume();
 			setting_min = VOLUME_MIN;
 			setting_max = VOLUME_MAX;
 		}
-		
-		int asset = show_setting==1?ASSET_BRIGHTNESS:(setting_value>0?ASSET_VOLUME:ASSET_VOLUME_MUTE);
-		int ax = ox + (show_setting==1 ? SCALE1(6) : SCALE1(8));
-		int ay = oy + (show_setting==1 ? SCALE1(5) : SCALE1(7));
-		GFX_blitAsset(asset, NULL, dst, &(SDL_Rect){ax,ay});
-		
+
+		int asset = show_setting == 1 ? ASSET_BRIGHTNESS : (setting_value > 0 ? ASSET_VOLUME : ASSET_VOLUME_MUTE);
+		int ax = ox + (show_setting == 1 ? SCALE1(6) : SCALE1(8));
+		int ay = oy + (show_setting == 1 ? SCALE1(5) : SCALE1(7));
+		GFX_blitAsset(asset, NULL, dst, &(SDL_Rect){ax, ay});
+
 		ox += SCALE1(PILL_SIZE);
 		oy += SCALE1((PILL_SIZE - SETTINGS_SIZE) / 2);
-		GFX_blitPill(gfx.mode==MODE_MAIN ? ASSET_BAR_BG : ASSET_BAR_BG_MENU, dst, &(SDL_Rect){
-			ox,
-			oy,
-			SCALE1(SETTINGS_WIDTH),
-			SCALE1(SETTINGS_SIZE)
-		});
-		
-		float percent = ((float)(setting_value-setting_min) / (setting_max-setting_min));
-		if (show_setting==1 || setting_value>0) {
-			GFX_blitPill(ASSET_BAR, dst, &(SDL_Rect){
-				ox,
-				oy,
-				SCALE1(SETTINGS_WIDTH) * percent,
-				SCALE1(SETTINGS_SIZE)
-			});
+		GFX_blitPill(gfx.mode == MODE_MAIN ? ASSET_BAR_BG : ASSET_BAR_BG_MENU, dst, &(SDL_Rect){ox, oy, SCALE1(SETTINGS_WIDTH), SCALE1(SETTINGS_SIZE)});
+
+		float percent = ((float)(setting_value - setting_min) / (setting_max - setting_min));
+		if (show_setting == 1 || setting_value > 0)
+		{
+			GFX_blitPill(ASSET_BAR, dst, &(SDL_Rect){ox, oy, SCALE1(SETTINGS_WIDTH) * percent, SCALE1(SETTINGS_SIZE)});
 		}
 	}
-	else {
+	else
+	{
 		// TODO: handle wifi
 		int show_wifi = PLAT_isOnline(); // NOOOOO! not every frame!
 
-		int ww = SCALE1(PILL_SIZE-3);
+		int ww = SCALE1(PILL_SIZE - 3);
 		ow = SCALE1(PILL_SIZE);
-		if (show_wifi) ow += ww;
+		if (show_wifi)
+			ow += ww;
 
 		ox = dst->w - SCALE1(PADDING) - ow;
 		oy = SCALE1(PADDING);
-		GFX_blitPill(gfx.mode==MODE_MAIN ? ASSET_DARK_GRAY_PILL : ASSET_BLACK_PILL, dst, &(SDL_Rect){
-			ox,
-			oy,
-			ow,
-			SCALE1(PILL_SIZE)
-		});
-		if (show_wifi) {
+		GFX_blitPill(gfx.mode == MODE_MAIN ? ASSET_DARK_GRAY_PILL : ASSET_BLACK_PILL, dst, &(SDL_Rect){ox, oy, ow, SCALE1(PILL_SIZE)});
+		if (show_wifi)
+		{
 			SDL_Rect rect = asset_rects[ASSET_WIFI];
 			int x = ox;
 			int y = oy;
 			x += (SCALE1(PILL_SIZE) - rect.w) / 2;
 			y += (SCALE1(PILL_SIZE) - rect.h) / 2;
-			
-			GFX_blitAsset(ASSET_WIFI, NULL, dst, &(SDL_Rect){x,y});
+
+			GFX_blitAsset(ASSET_WIFI, NULL, dst, &(SDL_Rect){x, y});
 			ox += ww;
 		}
-		GFX_blitBattery(dst, &(SDL_Rect){ox,oy});
+		GFX_blitBattery(dst, &(SDL_Rect){ox, oy});
 	}
-	
+
 	return ow;
 }
-void GFX_blitHardwareHints(SDL_Surface* dst, int show_setting) {
-	if (BTN_MOD_VOLUME==BTN_SELECT && BTN_MOD_BRIGHTNESS==BTN_START) {
-		if (show_setting==1) GFX_blitButtonGroup((char*[]){ "SELECT","VOLUME",  NULL }, 0, dst, 0);
-		else GFX_blitButtonGroup((char*[]){ "START","BRIGHTNESS",  NULL }, 0, dst, 0);
+void GFX_blitHardwareHints(SDL_Surface *dst, int show_setting)
+{
+	if (BTN_MOD_VOLUME == BTN_SELECT && BTN_MOD_BRIGHTNESS == BTN_START)
+	{
+		if (show_setting == 1)
+			GFX_blitButtonGroup((char *[]){"SELECT", "VOLUME", NULL}, 0, dst, 0);
+		else
+			GFX_blitButtonGroup((char *[]){"START", "BRIGHTNESS", NULL}, 0, dst, 0);
 	}
-	else {
-		if (show_setting==1) GFX_blitButtonGroup((char*[]){ BRIGHTNESS_BUTTON_LABEL,"BRIGHTNESS",  NULL }, 0, dst, 0);
-		else GFX_blitButtonGroup((char*[]){ "MENU","BRIGHTNESS",  NULL }, 0, dst, 0);
+	else
+	{
+		if (show_setting == 1)
+			GFX_blitButtonGroup((char *[]){BRIGHTNESS_BUTTON_LABEL, "BRIGHTNESS", NULL}, 0, dst, 0);
+		else
+			GFX_blitButtonGroup((char *[]){"MENU", "BRIGHTNESS", NULL}, 0, dst, 0);
 	}
-	
 }
 
-int GFX_blitButtonGroup(char** pairs, int primary, SDL_Surface* dst, int align_right) {
+int GFX_blitButtonGroup(char **pairs, int primary, SDL_Surface *dst, int align_right)
+{
 	int ox;
 	int oy;
 	int ow;
-	char* hint;
-	char* button;
+	char *hint;
+	char *button;
 
-	struct Hint {
-		char* hint;
-		char* button;
+	struct Hint
+	{
+		char *hint;
+		char *button;
 		int ow;
-	} hints[2]; 
+	} hints[2];
 	int w = 0; // individual button dimension
 	int h = 0; // hints index
-	ow = 0; // full pill width
+	ow = 0;	   // full pill width
 	ox = align_right ? dst->w - SCALE1(PADDING) : SCALE1(PADDING);
 	oy = dst->h - SCALE1(PADDING + PILL_SIZE);
-	
-	for (int i=0; i<2; i++) {
-		if (!pairs[i*2]) break;
-		if (HAS_SKINNY_SCREEN && i!=primary) continue; // space saving
-		
+
+	for (int i = 0; i < 2; i++)
+	{
+		if (!pairs[i * 2])
+			break;
+		if (HAS_SKINNY_SCREEN && i != primary)
+			continue; // space saving
+
 		button = pairs[i * 2];
 		hint = pairs[i * 2 + 1];
 		w = GFX_getButtonWidth(hint, button);
@@ -818,92 +913,107 @@ int GFX_blitButtonGroup(char** pairs, int primary, SDL_Surface* dst, int align_r
 		h += 1;
 		ow += SCALE1(BUTTON_MARGIN) + w;
 	}
-	
+
 	ow += SCALE1(BUTTON_MARGIN);
-	if (align_right) ox -= ow;
-	GFX_blitPill(gfx.mode==MODE_MAIN ? ASSET_DARK_GRAY_PILL : ASSET_BLACK_PILL, dst, &(SDL_Rect){
-		ox,
-		oy,
-		ow,
-		SCALE1(PILL_SIZE)
-	});
-	
+	if (align_right)
+		ox -= ow;
+	GFX_blitPill(gfx.mode == MODE_MAIN ? ASSET_DARK_GRAY_PILL : ASSET_BLACK_PILL, dst, &(SDL_Rect){ox, oy, ow, SCALE1(PILL_SIZE)});
+
 	ox += SCALE1(BUTTON_MARGIN);
 	oy += SCALE1(BUTTON_MARGIN);
-	for (int i=0; i<h; i++) {
-		GFX_blitButton(hints[i].hint, hints[i].button, dst, &(SDL_Rect){ox,oy});
+	for (int i = 0; i < h; i++)
+	{
+		GFX_blitButton(hints[i].hint, hints[i].button, dst, &(SDL_Rect){ox, oy});
 		ox += hints[i].ow + SCALE1(BUTTON_MARGIN);
 	}
 	return ow;
 }
 
 #define MAX_TEXT_LINES 16
-void GFX_sizeText(TTF_Font* font, char* str, int leading, int* w, int* h) {
-	char* lines[MAX_TEXT_LINES];
+void GFX_sizeText(TTF_Font *font, char *str, int leading, int *w, int *h)
+{
+	char *lines[MAX_TEXT_LINES];
 	int count = 0;
 
-	char* tmp;
+	char *tmp;
 	lines[count++] = str;
-	while ((tmp=strchr(lines[count-1], '\n'))!=NULL) {
-		if (count+1>MAX_TEXT_LINES) break; // TODO: bail?
-		lines[count++] = tmp+1;
+	while ((tmp = strchr(lines[count - 1], '\n')) != NULL)
+	{
+		if (count + 1 > MAX_TEXT_LINES)
+			break; // TODO: bail?
+		lines[count++] = tmp + 1;
 	}
 	*h = count * leading;
-	
+
 	int mw = 0;
 	char line[256];
-	for (int i=0; i<count; i++) {
+	for (int i = 0; i < count; i++)
+	{
 		int len;
-		if (i+1<count) {
-			len = lines[i+1]-lines[i]-1;
-			if (len) strncpy(line, lines[i], len);
+		if (i + 1 < count)
+		{
+			len = lines[i + 1] - lines[i] - 1;
+			if (len)
+				strncpy(line, lines[i], len);
 			line[len] = '\0';
 		}
-		else {
+		else
+		{
 			len = strlen(lines[i]);
 			strcpy(line, lines[i]);
 		}
-		
-		if (len) {
+
+		if (len)
+		{
 			int lw;
 			TTF_SizeUTF8(font, line, &lw, NULL);
-			if (lw>mw) mw = lw;
+			if (lw > mw)
+				mw = lw;
 		}
 	}
 	*w = mw;
 }
-void GFX_blitText(TTF_Font* font, char* str, int leading, SDL_Color color, SDL_Surface* dst, SDL_Rect* dst_rect) {
-	if (dst_rect==NULL) dst_rect = &(SDL_Rect){0,0,dst->w,dst->h};
-	
-	char* lines[MAX_TEXT_LINES];
+void GFX_blitText(TTF_Font *font, char *str, int leading, SDL_Color color, SDL_Surface *dst, SDL_Rect *dst_rect)
+{
+	if (dst_rect == NULL)
+		dst_rect = &(SDL_Rect){0, 0, dst->w, dst->h};
+
+	char *lines[MAX_TEXT_LINES];
 	int count = 0;
 
-	char* tmp;
+	char *tmp;
 	lines[count++] = str;
-	while ((tmp=strchr(lines[count-1], '\n'))!=NULL) {
-		if (count+1>MAX_TEXT_LINES) break; // TODO: bail?
-		lines[count++] = tmp+1;
+	while ((tmp = strchr(lines[count - 1], '\n')) != NULL)
+	{
+		if (count + 1 > MAX_TEXT_LINES)
+			break; // TODO: bail?
+		lines[count++] = tmp + 1;
 	}
 	int x = dst_rect->x;
 	int y = dst_rect->y;
-	
-	SDL_Surface* text;
+
+	SDL_Surface *text;
 	char line[256];
-	for (int i=0; i<count; i++) {
+	for (int i = 0; i < count; i++)
+	{
 		int len;
-		if (i+1<count) {
-			len = lines[i+1]-lines[i]-1;
-			if (len) strncpy(line, lines[i], len);
+		if (i + 1 < count)
+		{
+			len = lines[i + 1] - lines[i] - 1;
+			if (len)
+				strncpy(line, lines[i], len);
 			line[len] = '\0';
 		}
-		else {
+		else
+		{
 			len = strlen(lines[i]);
 			strcpy(line, lines[i]);
 		}
-		
-		if (len) {
+
+		if (len)
+		{
 			text = TTF_RenderUTF8_Blended(font, line, color);
-			SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){x+((dst_rect->w-text->w)/2),y+(i*leading)});
+			SDL_BlitSurface(text, NULL, dst, &(SDL_Rect){x + ((dst_rect->w - text->w) / 2), y + (i * leading)});
 			SDL_FreeSurface(text);
 		}
 	}
@@ -911,167 +1021,345 @@ void GFX_blitText(TTF_Font* font, char* str, int leading, SDL_Color color, SDL_S
 
 ///////////////////////////////
 
-// based on picoarch's audio 
-// implementation, rewritten 
-// to (try to) understand it 
+// based on picoarch's audio
+// implementation, rewritten
+// to (try to) understand it
 // better
 
 #define MAX_SAMPLE_RATE 48000
 #define BATCH_SIZE 100
 #ifndef SAMPLES
-	#define SAMPLES 512 // default
+#define SAMPLES 512 // default
 #endif
 
 #define ms SDL_GetTicks
 
 typedef int (*SND_Resampler)(const SND_Frame frame);
-static struct SND_Context {
+static struct SND_Context
+{
 	int initialized;
 	double frame_rate;
-	
+
 	int sample_rate_in;
 	int sample_rate_out;
-	
-	int buffer_seconds;     // current_audio_buffer_size
-	SND_Frame* buffer;		// buf
-	size_t frame_count; 	// buf_len
-	
-	int frame_in;     // buf_w
-	int frame_out;    // buf_r
+
+	int buffer_seconds; // current_audio_buffer_size
+	SND_Frame *buffer;	// buf
+	size_t frame_count; // buf_len
+
+	int frame_in;	  // buf_w
+	int frame_out;	  // buf_r
 	int frame_filled; // max_buf_w
-	
+
 	SND_Resampler resample;
 } snd = {0};
-static void SND_audioCallback(void* userdata, uint8_t* stream, int len) { // plat_sound_callback
-	
+static void SND_audioCallback(void *userdata, uint8_t *stream, int len)
+{ // plat_sound_callback
+
 	// return (void)memset(stream,0,len); // TODO: tmp, silent
-	
-	if (snd.frame_count==0) return;
-	
+
+	if (snd.frame_count == 0)
+		return;
+
 	int16_t *out = (int16_t *)stream;
 	len /= (sizeof(int16_t) * 2);
 	// int full_len = len;
-	
+
 	// if (snd.frame_out!=snd.frame_in) LOG_info("%8i consuming samples (%i frames)\n", ms(), len);
-	
-	while (snd.frame_out!=snd.frame_in && len>0) {
+
+	while (snd.frame_out != snd.frame_in && len > 0)
+	{
 		*out++ = snd.buffer[snd.frame_out].left;
 		*out++ = snd.buffer[snd.frame_out].right;
-		
-		snd.frame_filled = snd.frame_out;
-		
+
 		snd.frame_out += 1;
 		len -= 1;
-		
-		if (snd.frame_out>=snd.frame_count) snd.frame_out = 0;
+
+		if (snd.frame_out >= snd.frame_count)
+			snd.frame_out = 0;
 	}
-	
-	int zero = len>0 && len==SAMPLES;
-	if (zero) return (void)memset(out,0,len*(sizeof(int16_t) * 2));
+	snd.frame_filled = snd.frame_out;
+
+	if (len > 0)
+	{
+		LOG_info("overrun");
+	}
+	int zero = len > 0 && len == SAMPLES;
+	if (zero)
+		return (void)memset(out, 0, len * (sizeof(int16_t) * 2));
 	// else if (len>=5) LOG_info("%8i BUFFER UNDERRUN (%i/%i frames)\n", ms(), len,full_len);
 
-	int16_t *in = out-1;
-	while (len>0) {
-		*out++ = (void*)in>(void*)stream ? *--in : 0;
-		*out++ = (void*)in>(void*)stream ? *--in : 0;
+	int16_t *in = out - 1;
+	while (len > 0)
+	{
+		*out++ = (void *)in > (void *)stream ? *--in : 0;
+		*out++ = (void *)in > (void *)stream ? *--in : 0;
 		len -= 1;
 	}
 }
-static void SND_resizeBuffer(void) { // plat_sound_resize_buffer
+static void SND_resizeBuffer(void)
+{ // plat_sound_resize_buffer
 	snd.frame_count = snd.buffer_seconds * snd.sample_rate_in / snd.frame_rate;
-	if (snd.frame_count==0) return;
-	
+	if (snd.frame_count == 0)
+		return;
+
 	// LOG_info("frame_count: %i (%i * %i / %f)\n", snd.frame_count, snd.buffer_seconds, snd.sample_rate_in, snd.frame_rate);
 	// snd.frame_count *= 2; // no help
-	
+
 	SDL_LockAudio();
-	
+
 	int buffer_bytes = snd.frame_count * sizeof(SND_Frame);
 	snd.buffer = realloc(snd.buffer, buffer_bytes);
-	
+
 	memset(snd.buffer, 0, buffer_bytes);
-	
+
 	snd.frame_in = 0;
 	snd.frame_out = 0;
 	snd.frame_filled = snd.frame_count - 1;
-	
+
 	SDL_UnlockAudio();
 }
-static int SND_resampleNone(SND_Frame frame) { // audio_resample_passthrough
+
+ResampledFrames resample_audio(const SND_Frame *input_frames, int input_frame_count,
+							   int input_sample_rate, int output_sample_rate, double ratio)
+{
+	int error;
+
+	// Initialize SRC state for left and right channels
+	SRC_STATE *src_state_left = src_new(SRC_LINEAR, 1, &error);
+	if (error != 0)
+	{
+		fprintf(stderr, "Error initializing SRC state: %s\n", src_strerror(error));
+		exit(1);
+	}
+	SRC_STATE *src_state_right = src_new(SRC_LINEAR, 1, &error);
+	if (error != 0)
+	{
+		fprintf(stderr, "Error initializing SRC state: %s\n", src_strerror(error));
+		src_delete(src_state_left);
+		exit(1);
+	}
+
+	// Calculate the expected number of output frames
+	int output_frame_count = (int)(input_frame_count * ratio);
+
+	// Allocate input and output buffers for left and right channels
+	float *input_buffer_left = malloc(input_frame_count * sizeof(float));
+	float *input_buffer_right = malloc(input_frame_count * sizeof(float));
+	float *output_buffer_left = malloc(output_frame_count * sizeof(float));
+	float *output_buffer_right = malloc(output_frame_count * sizeof(float));
+	if (!input_buffer_left || !input_buffer_right || !output_buffer_left || !output_buffer_right)
+	{
+		fprintf(stderr, "Error allocating buffers\n");
+		free(input_buffer_left);
+		free(input_buffer_right);
+		free(output_buffer_left);
+		free(output_buffer_right);
+		src_delete(src_state_left);
+		src_delete(src_state_right);
+		exit(1);
+	}
+
+	// Split input frames into left and right channels
+	for (int i = 0; i < input_frame_count; i++)
+	{
+		input_buffer_left[i] = (float)input_frames[i].left / 32768.0f;
+		input_buffer_right[i] = (float)input_frames[i].right / 32768.0f;
+	}
+
+	// Prepare SRC_DATA structures for left and right channels
+	SRC_DATA src_data_left = {
+		.data_in = input_buffer_left,
+		.data_out = output_buffer_left,
+		.input_frames = input_frame_count,
+		.output_frames = output_frame_count,
+		.src_ratio = ratio};
+
+	SRC_DATA src_data_right = {
+		.data_in = input_buffer_right,
+		.data_out = output_buffer_right,
+		.input_frames = input_frame_count,
+		.output_frames = output_frame_count,
+		.src_ratio = ratio};
+
+	// Perform resampling
+	if (src_process(src_state_left, &src_data_left) != 0)
+	{
+		fprintf(stderr, "Error resampling left channel: %s\n", src_strerror(src_error(src_state_left)));
+		free(input_buffer_left);
+		free(input_buffer_right);
+		free(output_buffer_left);
+		free(output_buffer_right);
+		src_delete(src_state_left);
+		src_delete(src_state_right);
+		exit(1);
+	}
+	if (src_process(src_state_right, &src_data_right) != 0)
+	{
+		fprintf(stderr, "Error resampling right channel: %s\n", src_strerror(src_error(src_state_right)));
+		free(input_buffer_left);
+		free(input_buffer_right);
+		free(output_buffer_left);
+		free(output_buffer_right);
+		src_delete(src_state_left);
+		src_delete(src_state_right);
+		exit(1);
+	}
+
+	// Clean up SRC states
+	src_delete(src_state_left);
+	src_delete(src_state_right);
+
+	// Allocate output frames
+	SND_Frame *output_frames = malloc(output_frame_count * sizeof(SND_Frame));
+	if (!output_frames)
+	{
+		fprintf(stderr, "Error allocating output frames\n");
+		free(output_buffer_left);
+		free(output_buffer_right);
+		exit(1);
+	}
+
+	// Combine resampled left and right channels into output frames
+	for (int i = 0; i < output_frame_count; i++)
+	{
+		output_frames[i].left = (int16_t)(output_buffer_left[i] * 32768.0f);
+		output_frames[i].right = (int16_t)(output_buffer_right[i] * 32768.0f);
+	}
+
+	// Free temporary buffers
+	free(output_buffer_left);
+	free(output_buffer_right);
+	free(input_buffer_left);
+	free(input_buffer_right);
+
+	// Return the resampled frames
+	ResampledFrames resampled;
+	resampled.frames = output_frames;
+	resampled.frame_count = output_frame_count;
+
+	return resampled;
+}
+
+static int SND_resampleNone(SND_Frame frame)
+{ // audio_resample_passthrough
 	snd.buffer[snd.frame_in++] = frame;
-	if (snd.frame_in >= snd.frame_count) snd.frame_in = 0;
+	if (snd.frame_in >= snd.frame_count)
+		snd.frame_in = 0;
 	return 1;
 }
-static int SND_resampleNear(SND_Frame frame) { // audio_resample_nearest
+static int SND_resampleNear(SND_Frame frame)
+{ // audio_resample_nearest
 	static int diff = 0;
 	int consumed = 0;
 
-	if (diff < snd.sample_rate_out) {
+	if (diff < snd.sample_rate_out)
+	{
 		snd.buffer[snd.frame_in++] = frame;
-		if (snd.frame_in >= snd.frame_count) snd.frame_in = 0;
+		if (snd.frame_in >= snd.frame_count)
+			snd.frame_in = 0;
 		diff += snd.sample_rate_in;
 	}
 
-	if (diff >= snd.sample_rate_out) {
+	if (diff >= snd.sample_rate_out)
+	{
 		consumed++;
 		diff -= snd.sample_rate_out;
 	}
 
 	return consumed;
 }
-static void SND_selectResampler(void) { // plat_sound_select_resampler
-	if (snd.sample_rate_in==snd.sample_rate_out) {
-		snd.resample =  SND_resampleNone;
+static void SND_selectResampler(void)
+{ // plat_sound_select_resampler
+	if (snd.sample_rate_in == snd.sample_rate_out)
+	{
+		snd.resample = SND_resampleNone;
 	}
-	else {
+	else
+	{
 		snd.resample = SND_resampleNear;
 	}
 }
-size_t SND_batchSamples(const SND_Frame* frames, size_t frame_count) {
-    if (snd.frame_count == 0)
-        return 0;
+float dynamic_rate_adjust = 0.0001;
+size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
+{
+	static double ratio = 1.0;
+	if (snd.frame_count == 0)
+		return 0;
 
-    SDL_LockAudio();
+	SDL_LockAudio();
 
-    int consumed = 0;
-    int consumed_frames = 0;
-    while (frame_count > 0) {
-        int amount = MIN(BATCH_SIZE, frame_count);
+	int consumed = 0;
+	int consumed_frames = 0;
 
-        // If the buffer is full, skip the frames
-        if ((snd.frame_in + 1) % snd.frame_count == snd.frame_out) {
-            frames += amount;
-            frame_count -= amount;
-            continue;
-        }
+	// LOG_info("batch %i frames\n", frame_count);
+	SND_Frame tmpbuffer[frame_count];
+	int i = 0;
+	while (i < frame_count)
+	{
+		tmpbuffer[i] = frames[i];
+		i++;
+	}
 
-        while (amount && snd.frame_in != snd.frame_filled) {
-            consumed_frames = snd.resample(*frames);
+	int remaining_space = (snd.frame_in >= snd.frame_filled) ? (snd.frame_count - (snd.frame_in - snd.frame_filled)) : (snd.frame_filled - snd.frame_in);
 
-            frames += consumed_frames;
-            amount -= consumed_frames;
-            frame_count -= consumed_frames;
-            consumed += consumed_frames;
-        }
-    }
+	if (remaining_space < (snd.frame_count / 4))
+	{
+		// Decrease ratio to slow down the input rate if the buffer is filling up
+		ratio -= 0.001;
+	}
+	else if (remaining_space > (3 * snd.frame_count / 4))
+	{
+		// Increase ratio to speed up the input rate if the buffer has enough space
+		ratio += 0.001;
+	}
 
-    SDL_UnlockAudio();
-    return consumed;
+	if (ratio < 0.8)
+		ratio = 0.8;
+	if (ratio > 1.2)
+		ratio = 1.2;
+
+	LOG_info("resample ratio: %f\n", ratio);
+	// LOG_info("stored in tmpbbuffer %i frames\n", i);
+	ResampledFrames resampled = resample_audio(tmpbuffer, frame_count, snd.sample_rate_in, snd.sample_rate_out, ratio);
+	// LOG_info("resampled %i frames\n", resampled.frame_count);
+	SND_Frame *resampled_frames = resampled.frames;
+	int resampled_frame_count = resampled.frame_count;
+	int b = 0;
+	while (b < resampled_frame_count && (snd.frame_in + 1) % snd.frame_count != snd.frame_out)
+	{
+		snd.buffer[snd.frame_in++] = resampled_frames[b++];
+		if (snd.frame_in >= snd.frame_count)
+			snd.frame_in = 0;
+		consumed_frames++;
+
+		frame_count -= consumed_frames;
+		consumed += consumed_frames;
+	}
+
+	snd.frame_filled = snd.frame_in;
+
+	free(resampled.frames);
+	// LOG_info("batch done unlock\n", frame_count);
+	SDL_UnlockAudio();
+	return consumed;
 }
 
-void SND_init(double sample_rate, double frame_rate) { // plat_sound_init
+void SND_init(double sample_rate, double frame_rate)
+{ // plat_sound_init
 	LOG_info("SND_init\n");
-	
+
 	SDL_InitSubSystem(SDL_INIT_AUDIO);
-	
+
 #if defined(USE_SDL2)
 	LOG_info("Available audio drivers:\n");
-	for (int i=0; i<SDL_GetNumAudioDrivers(); i++) {
+	for (int i = 0; i < SDL_GetNumAudioDrivers(); i++)
+	{
 		LOG_info("- %s\n", SDL_GetAudioDriver(i));
 	}
 	LOG_info("Current audio driver: %s\n", SDL_GetCurrentAudioDriver());
-#endif	
-	
+#endif
+
 	memset(&snd, 0, sizeof(struct SND_Context));
 	snd.frame_rate = frame_rate;
 
@@ -1083,28 +1371,32 @@ void SND_init(double sample_rate, double frame_rate) { // plat_sound_init
 	spec_in.channels = 2;
 	spec_in.samples = SAMPLES;
 	spec_in.callback = SND_audioCallback;
-	
-	if (SDL_OpenAudio(&spec_in, &spec_out)<0) LOG_info("SDL_OpenAudio error: %s\n", SDL_GetError());
-	
-	snd.buffer_seconds = 5;
-	snd.sample_rate_in  = sample_rate;
+
+	if (SDL_OpenAudio(&spec_in, &spec_out) < 0)
+		LOG_info("SDL_OpenAudio error: %s\n", SDL_GetError());
+
+	snd.buffer_seconds = 8;
+	snd.sample_rate_in = sample_rate;
 	snd.sample_rate_out = spec_out.freq;
-	
+
 	SND_selectResampler();
 	SND_resizeBuffer();
-	
+
 	SDL_PauseAudio(0);
 
 	LOG_info("sample rate: %i (req) %i (rec) [samples %i]\n", snd.sample_rate_in, snd.sample_rate_out, SAMPLES);
 	snd.initialized = 1;
 }
-void SND_quit(void) { // plat_sound_finish
-	if (!snd.initialized) return;
-	
+void SND_quit(void)
+{ // plat_sound_finish
+	if (!snd.initialized)
+		return;
+
 	SDL_PauseAudio(1);
 	SDL_CloseAudio();
-	
-	if (snd.buffer) {
+
+	if (snd.buffer)
+	{
 		free(snd.buffer);
 		snd.buffer = NULL;
 	}
@@ -1117,292 +1409,571 @@ LID_Context lid = {
 	.is_open = 1,
 };
 
-FALLBACK_IMPLEMENTATION void PLAT_initLid(void) {  }
-FALLBACK_IMPLEMENTATION int PLAT_lidChanged(int* state) { return 0; }
+FALLBACK_IMPLEMENTATION void PLAT_initLid(void) {}
+FALLBACK_IMPLEMENTATION int PLAT_lidChanged(int *state) { return 0; }
 
 ///////////////////////////////
 
 PAD_Context pad;
 
 #define AXIS_DEADZONE 0x4000
-void PAD_setAnalog(int neg_id,int pos_id,int value,int repeat_at) {
+void PAD_setAnalog(int neg_id, int pos_id, int value, int repeat_at)
+{
 	// LOG_info("neg %i pos %i value %i\n", neg_id, pos_id, value);
 	int neg = 1 << neg_id;
-	int pos = 1 << pos_id;	
-	if (value>AXIS_DEADZONE) { // pressing
-		if (!(pad.is_pressed&pos)) { // not pressing
-			pad.is_pressed 		|= pos; // set
-			pad.just_pressed	|= pos; // set
-			pad.just_repeated	|= pos; // set
-			pad.repeat_at[pos_id]= repeat_at;
-		
-			if (pad.is_pressed&neg) { // was pressing opposite
-				pad.is_pressed 		&= ~neg; // unset
-				pad.just_repeated 	&= ~neg; // unset
-				pad.just_released	|=  neg; // set
+	int pos = 1 << pos_id;
+	if (value > AXIS_DEADZONE)
+	{ // pressing
+		if (!(pad.is_pressed & pos))
+		{							  // not pressing
+			pad.is_pressed |= pos;	  // set
+			pad.just_pressed |= pos;  // set
+			pad.just_repeated |= pos; // set
+			pad.repeat_at[pos_id] = repeat_at;
+
+			if (pad.is_pressed & neg)
+			{							   // was pressing opposite
+				pad.is_pressed &= ~neg;	   // unset
+				pad.just_repeated &= ~neg; // unset
+				pad.just_released |= neg;  // set
 			}
 		}
 	}
-	else if (value<-AXIS_DEADZONE) { // pressing
-		if (!(pad.is_pressed&neg)) { // not pressing
-			pad.is_pressed		|= neg; // set
-			pad.just_pressed	|= neg; // set
-			pad.just_repeated	|= neg; // set
-			pad.repeat_at[neg_id]= repeat_at;
-		
-			if (pad.is_pressed&pos) { // was pressing opposite
-				pad.is_pressed 		&= ~pos; // unset
-				pad.just_repeated 	&= ~pos; // unset
-				pad.just_released	|=  pos; // set
+	else if (value < -AXIS_DEADZONE)
+	{ // pressing
+		if (!(pad.is_pressed & neg))
+		{							  // not pressing
+			pad.is_pressed |= neg;	  // set
+			pad.just_pressed |= neg;  // set
+			pad.just_repeated |= neg; // set
+			pad.repeat_at[neg_id] = repeat_at;
+
+			if (pad.is_pressed & pos)
+			{							   // was pressing opposite
+				pad.is_pressed &= ~pos;	   // unset
+				pad.just_repeated &= ~pos; // unset
+				pad.just_released |= pos;  // set
 			}
 		}
 	}
-	else { // not pressing
-		if (pad.is_pressed&neg) { // was pressing
-			pad.is_pressed 		&= ~neg; // unset
-			pad.just_repeated	&=  neg; // unset
-			pad.just_released	|=  neg; // set
+	else
+	{ // not pressing
+		if (pad.is_pressed & neg)
+		{							  // was pressing
+			pad.is_pressed &= ~neg;	  // unset
+			pad.just_repeated &= neg; // unset
+			pad.just_released |= neg; // set
 		}
-		if (pad.is_pressed&pos) { // was pressing
-			pad.is_pressed 		&= ~pos; // unset
-			pad.just_repeated	&=  pos; // unset
-			pad.just_released	|=  pos; // set
+		if (pad.is_pressed & pos)
+		{							  // was pressing
+			pad.is_pressed &= ~pos;	  // unset
+			pad.just_repeated &= pos; // unset
+			pad.just_released |= pos; // set
 		}
 	}
 }
 
-void PAD_reset(void) {
+void PAD_reset(void)
+{
 	// LOG_info("PAD_reset");
 	pad.just_pressed = BTN_NONE;
 	pad.is_pressed = BTN_NONE;
 	pad.just_released = BTN_NONE;
 	pad.just_repeated = BTN_NONE;
 }
-FALLBACK_IMPLEMENTATION void PLAT_pollInput(void) {
+FALLBACK_IMPLEMENTATION void PLAT_pollInput(void)
+{
 	// reset transient state
 	pad.just_pressed = BTN_NONE;
 	pad.just_released = BTN_NONE;
 	pad.just_repeated = BTN_NONE;
 
 	uint32_t tick = SDL_GetTicks();
-	for (int i=0; i<BTN_ID_COUNT; i++) {
+	for (int i = 0; i < BTN_ID_COUNT; i++)
+	{
 		int btn = 1 << i;
-		if ((pad.is_pressed & btn) && (tick>=pad.repeat_at[i])) {
+		if ((pad.is_pressed & btn) && (tick >= pad.repeat_at[i]))
+		{
 			pad.just_repeated |= btn; // set
 			pad.repeat_at[i] += PAD_REPEAT_INTERVAL;
 		}
 	}
-	
+
 	// the actual poll
 	SDL_Event event;
-	while (SDL_PollEvent(&event)) {
+	while (SDL_PollEvent(&event))
+	{
 		int btn = BTN_NONE;
 		int pressed = 0; // 0=up,1=down
 		int id = -1;
-		if (event.type==SDL_KEYDOWN || event.type==SDL_KEYUP) {
+		if (event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
+		{
 			uint8_t code = event.key.keysym.scancode;
-			pressed = event.type==SDL_KEYDOWN;
+			pressed = event.type == SDL_KEYDOWN;
 			// LOG_info("key event: %i (%i)\n", code,pressed);
-				 if (code==CODE_UP) 		{ btn = BTN_DPAD_UP; 		id = BTN_ID_DPAD_UP; }
- 			else if (code==CODE_DOWN)		{ btn = BTN_DPAD_DOWN; 		id = BTN_ID_DPAD_DOWN; }
-			else if (code==CODE_LEFT)		{ btn = BTN_DPAD_LEFT; 		id = BTN_ID_DPAD_LEFT; }
-			else if (code==CODE_RIGHT)		{ btn = BTN_DPAD_RIGHT; 	id = BTN_ID_DPAD_RIGHT; }
-			else if (code==CODE_A)			{ btn = BTN_A; 				id = BTN_ID_A; }
-			else if (code==CODE_B)			{ btn = BTN_B; 				id = BTN_ID_B; }
-			else if (code==CODE_X)			{ btn = BTN_X; 				id = BTN_ID_X; }
-			else if (code==CODE_Y)			{ btn = BTN_Y; 				id = BTN_ID_Y; }
-			else if (code==CODE_START)		{ btn = BTN_START; 			id = BTN_ID_START; }
-			else if (code==CODE_SELECT)		{ btn = BTN_SELECT; 		id = BTN_ID_SELECT; }
-			else if (code==CODE_MENU)		{ btn = BTN_MENU; 			id = BTN_ID_MENU; }
-			else if (code==CODE_MENU_ALT)	{ btn = BTN_MENU; 			id = BTN_ID_MENU; }
-			else if (code==CODE_L1)			{ btn = BTN_L1; 			id = BTN_ID_L1; }
-			else if (code==CODE_L2)			{ btn = BTN_L2; 			id = BTN_ID_L2; }
-			else if (code==CODE_L3)			{ btn = BTN_L3; 			id = BTN_ID_L3; }
-			else if (code==CODE_R1)			{ btn = BTN_R1; 			id = BTN_ID_R1; }
-			else if (code==CODE_R2)			{ btn = BTN_R2; 			id = BTN_ID_R2; }
-			else if (code==CODE_R3)			{ btn = BTN_R3; 			id = BTN_ID_R3; }
-			else if (code==CODE_PLUS)		{ btn = BTN_PLUS; 			id = BTN_ID_PLUS; }
-			else if (code==CODE_MINUS)		{ btn = BTN_MINUS; 			id = BTN_ID_MINUS; }
-			else if (code==CODE_POWER)		{ btn = BTN_POWER; 			id = BTN_ID_POWER; }
-			else if (code==CODE_POWEROFF)	{ btn = BTN_POWEROFF;		id = BTN_ID_POWEROFF; } // nano-only
+			if (code == CODE_UP)
+			{
+				btn = BTN_DPAD_UP;
+				id = BTN_ID_DPAD_UP;
+			}
+			else if (code == CODE_DOWN)
+			{
+				btn = BTN_DPAD_DOWN;
+				id = BTN_ID_DPAD_DOWN;
+			}
+			else if (code == CODE_LEFT)
+			{
+				btn = BTN_DPAD_LEFT;
+				id = BTN_ID_DPAD_LEFT;
+			}
+			else if (code == CODE_RIGHT)
+			{
+				btn = BTN_DPAD_RIGHT;
+				id = BTN_ID_DPAD_RIGHT;
+			}
+			else if (code == CODE_A)
+			{
+				btn = BTN_A;
+				id = BTN_ID_A;
+			}
+			else if (code == CODE_B)
+			{
+				btn = BTN_B;
+				id = BTN_ID_B;
+			}
+			else if (code == CODE_X)
+			{
+				btn = BTN_X;
+				id = BTN_ID_X;
+			}
+			else if (code == CODE_Y)
+			{
+				btn = BTN_Y;
+				id = BTN_ID_Y;
+			}
+			else if (code == CODE_START)
+			{
+				btn = BTN_START;
+				id = BTN_ID_START;
+			}
+			else if (code == CODE_SELECT)
+			{
+				btn = BTN_SELECT;
+				id = BTN_ID_SELECT;
+			}
+			else if (code == CODE_MENU)
+			{
+				btn = BTN_MENU;
+				id = BTN_ID_MENU;
+			}
+			else if (code == CODE_MENU_ALT)
+			{
+				btn = BTN_MENU;
+				id = BTN_ID_MENU;
+			}
+			else if (code == CODE_L1)
+			{
+				btn = BTN_L1;
+				id = BTN_ID_L1;
+			}
+			else if (code == CODE_L2)
+			{
+				btn = BTN_L2;
+				id = BTN_ID_L2;
+			}
+			else if (code == CODE_L3)
+			{
+				btn = BTN_L3;
+				id = BTN_ID_L3;
+			}
+			else if (code == CODE_R1)
+			{
+				btn = BTN_R1;
+				id = BTN_ID_R1;
+			}
+			else if (code == CODE_R2)
+			{
+				btn = BTN_R2;
+				id = BTN_ID_R2;
+			}
+			else if (code == CODE_R3)
+			{
+				btn = BTN_R3;
+				id = BTN_ID_R3;
+			}
+			else if (code == CODE_PLUS)
+			{
+				btn = BTN_PLUS;
+				id = BTN_ID_PLUS;
+			}
+			else if (code == CODE_MINUS)
+			{
+				btn = BTN_MINUS;
+				id = BTN_ID_MINUS;
+			}
+			else if (code == CODE_POWER)
+			{
+				btn = BTN_POWER;
+				id = BTN_ID_POWER;
+			}
+			else if (code == CODE_POWEROFF)
+			{
+				btn = BTN_POWEROFF;
+				id = BTN_ID_POWEROFF;
+			} // nano-only
 		}
-		else if (event.type==SDL_JOYBUTTONDOWN || event.type==SDL_JOYBUTTONUP) {
+		else if (event.type == SDL_JOYBUTTONDOWN || event.type == SDL_JOYBUTTONUP)
+		{
 			uint8_t joy = event.jbutton.button;
-			pressed = event.type==SDL_JOYBUTTONDOWN;
+			pressed = event.type == SDL_JOYBUTTONDOWN;
 			// LOG_info("joy event: %i (%i)\n", joy,pressed);
-				 if (joy==JOY_UP) 		{ btn = BTN_DPAD_UP; 		id = BTN_ID_DPAD_UP; }
- 			else if (joy==JOY_DOWN)		{ btn = BTN_DPAD_DOWN; 		id = BTN_ID_DPAD_DOWN; }
-			else if (joy==JOY_LEFT)		{ btn = BTN_DPAD_LEFT; 		id = BTN_ID_DPAD_LEFT; }
-			else if (joy==JOY_RIGHT)	{ btn = BTN_DPAD_RIGHT; 	id = BTN_ID_DPAD_RIGHT; }
-			else if (joy==JOY_A)		{ btn = BTN_A; 				id = BTN_ID_A; }
-			else if (joy==JOY_B)		{ btn = BTN_B; 				id = BTN_ID_B; }
-			else if (joy==JOY_X)		{ btn = BTN_X; 				id = BTN_ID_X; }
-			else if (joy==JOY_Y)		{ btn = BTN_Y; 				id = BTN_ID_Y; }
-			else if (joy==JOY_START)	{ btn = BTN_START; 			id = BTN_ID_START; }
-			else if (joy==JOY_SELECT)	{ btn = BTN_SELECT; 		id = BTN_ID_SELECT; }
-			else if (joy==JOY_MENU)		{ btn = BTN_MENU; 			id = BTN_ID_MENU; }
-			else if (joy==JOY_MENU_ALT) { btn = BTN_MENU; 			id = BTN_ID_MENU; }
-			else if (joy==JOY_MENU_ALT2){ btn = BTN_MENU; 			id = BTN_ID_MENU; }
-			else if (joy==JOY_L1)		{ btn = BTN_L1; 			id = BTN_ID_L1; }
-			else if (joy==JOY_L2)		{ btn = BTN_L2; 			id = BTN_ID_L2; }
-			else if (joy==JOY_L3)		{ btn = BTN_L3; 			id = BTN_ID_L3; }
-			else if (joy==JOY_R1)		{ btn = BTN_R1; 			id = BTN_ID_R1; }
-			else if (joy==JOY_R2)		{ btn = BTN_R2; 			id = BTN_ID_R2; }
-			else if (joy==JOY_R3)		{ btn = BTN_R3; 			id = BTN_ID_R3; }
-			else if (joy==JOY_PLUS)		{ btn = BTN_PLUS; 			id = BTN_ID_PLUS; }
-			else if (joy==JOY_MINUS)	{ btn = BTN_MINUS; 			id = BTN_ID_MINUS; }
-			else if (joy==JOY_POWER)	{ btn = BTN_POWER; 			id = BTN_ID_POWER; }
+			if (joy == JOY_UP)
+			{
+				btn = BTN_DPAD_UP;
+				id = BTN_ID_DPAD_UP;
+			}
+			else if (joy == JOY_DOWN)
+			{
+				btn = BTN_DPAD_DOWN;
+				id = BTN_ID_DPAD_DOWN;
+			}
+			else if (joy == JOY_LEFT)
+			{
+				btn = BTN_DPAD_LEFT;
+				id = BTN_ID_DPAD_LEFT;
+			}
+			else if (joy == JOY_RIGHT)
+			{
+				btn = BTN_DPAD_RIGHT;
+				id = BTN_ID_DPAD_RIGHT;
+			}
+			else if (joy == JOY_A)
+			{
+				btn = BTN_A;
+				id = BTN_ID_A;
+			}
+			else if (joy == JOY_B)
+			{
+				btn = BTN_B;
+				id = BTN_ID_B;
+			}
+			else if (joy == JOY_X)
+			{
+				btn = BTN_X;
+				id = BTN_ID_X;
+			}
+			else if (joy == JOY_Y)
+			{
+				btn = BTN_Y;
+				id = BTN_ID_Y;
+			}
+			else if (joy == JOY_START)
+			{
+				btn = BTN_START;
+				id = BTN_ID_START;
+			}
+			else if (joy == JOY_SELECT)
+			{
+				btn = BTN_SELECT;
+				id = BTN_ID_SELECT;
+			}
+			else if (joy == JOY_MENU)
+			{
+				btn = BTN_MENU;
+				id = BTN_ID_MENU;
+			}
+			else if (joy == JOY_MENU_ALT)
+			{
+				btn = BTN_MENU;
+				id = BTN_ID_MENU;
+			}
+			else if (joy == JOY_MENU_ALT2)
+			{
+				btn = BTN_MENU;
+				id = BTN_ID_MENU;
+			}
+			else if (joy == JOY_L1)
+			{
+				btn = BTN_L1;
+				id = BTN_ID_L1;
+			}
+			else if (joy == JOY_L2)
+			{
+				btn = BTN_L2;
+				id = BTN_ID_L2;
+			}
+			else if (joy == JOY_L3)
+			{
+				btn = BTN_L3;
+				id = BTN_ID_L3;
+			}
+			else if (joy == JOY_R1)
+			{
+				btn = BTN_R1;
+				id = BTN_ID_R1;
+			}
+			else if (joy == JOY_R2)
+			{
+				btn = BTN_R2;
+				id = BTN_ID_R2;
+			}
+			else if (joy == JOY_R3)
+			{
+				btn = BTN_R3;
+				id = BTN_ID_R3;
+			}
+			else if (joy == JOY_PLUS)
+			{
+				btn = BTN_PLUS;
+				id = BTN_ID_PLUS;
+			}
+			else if (joy == JOY_MINUS)
+			{
+				btn = BTN_MINUS;
+				id = BTN_ID_MINUS;
+			}
+			else if (joy == JOY_POWER)
+			{
+				btn = BTN_POWER;
+				id = BTN_ID_POWER;
+			}
 		}
-		else if (event.type==SDL_JOYHATMOTION) {
-			int hats[4] = {-1,-1,-1,-1}; // -1=no change,0=up,1=down,2=left,3=right btn_ids
+		else if (event.type == SDL_JOYHATMOTION)
+		{
+			int hats[4] = {-1, -1, -1, -1}; // -1=no change,0=up,1=down,2=left,3=right btn_ids
 			int hat = event.jhat.value;
 			// LOG_info("hat event: %i\n", hat);
 			// TODO: safe to assume hats will always be the primary dpad?
 			// TODO: this is literally a bitmask, make it one (oh, except there's 3 states...)
-			switch (hat) {
-				case SDL_HAT_UP:			hats[0]=1;	  hats[1]=0;	hats[2]=0;	  hats[3]=0;	break;
-				case SDL_HAT_DOWN:			hats[0]=0;	  hats[1]=1;	hats[2]=0;	  hats[3]=0;	break;
-				case SDL_HAT_LEFT:			hats[0]=0;	  hats[1]=0;	hats[2]=1;	  hats[3]=0;	break;
-				case SDL_HAT_RIGHT:			hats[0]=0;	  hats[1]=0;	hats[2]=0;	  hats[3]=1;	break;
-				case SDL_HAT_LEFTUP:		hats[0]=1;	  hats[1]=0;	hats[2]=1;	  hats[3]=0;	break;
-				case SDL_HAT_LEFTDOWN:		hats[0]=0;	  hats[1]=1;	hats[2]=1;	  hats[3]=0;	break;
-				case SDL_HAT_RIGHTUP:		hats[0]=1;	  hats[1]=0;	hats[2]=0;	  hats[3]=1;	break;
-				case SDL_HAT_RIGHTDOWN:		hats[0]=0;	  hats[1]=1;	hats[2]=0;	  hats[3]=1;	break;
-				case SDL_HAT_CENTERED:		hats[0]=0;	  hats[1]=0;	hats[2]=0;	  hats[3]=0;	break;
-				default: break;
+			switch (hat)
+			{
+			case SDL_HAT_UP:
+				hats[0] = 1;
+				hats[1] = 0;
+				hats[2] = 0;
+				hats[3] = 0;
+				break;
+			case SDL_HAT_DOWN:
+				hats[0] = 0;
+				hats[1] = 1;
+				hats[2] = 0;
+				hats[3] = 0;
+				break;
+			case SDL_HAT_LEFT:
+				hats[0] = 0;
+				hats[1] = 0;
+				hats[2] = 1;
+				hats[3] = 0;
+				break;
+			case SDL_HAT_RIGHT:
+				hats[0] = 0;
+				hats[1] = 0;
+				hats[2] = 0;
+				hats[3] = 1;
+				break;
+			case SDL_HAT_LEFTUP:
+				hats[0] = 1;
+				hats[1] = 0;
+				hats[2] = 1;
+				hats[3] = 0;
+				break;
+			case SDL_HAT_LEFTDOWN:
+				hats[0] = 0;
+				hats[1] = 1;
+				hats[2] = 1;
+				hats[3] = 0;
+				break;
+			case SDL_HAT_RIGHTUP:
+				hats[0] = 1;
+				hats[1] = 0;
+				hats[2] = 0;
+				hats[3] = 1;
+				break;
+			case SDL_HAT_RIGHTDOWN:
+				hats[0] = 0;
+				hats[1] = 1;
+				hats[2] = 0;
+				hats[3] = 1;
+				break;
+			case SDL_HAT_CENTERED:
+				hats[0] = 0;
+				hats[1] = 0;
+				hats[2] = 0;
+				hats[3] = 0;
+				break;
+			default:
+				break;
 			}
-			
-			for (id=0; id<4; id++) {
+
+			for (id = 0; id < 4; id++)
+			{
 				int state = hats[id];
 				btn = 1 << id;
-				if (state==0) {
-					pad.is_pressed		&= ~btn; // unset
-					pad.just_repeated	&= ~btn; // unset
-					pad.just_released	|= btn; // set
+				if (state == 0)
+				{
+					pad.is_pressed &= ~btn;	   // unset
+					pad.just_repeated &= ~btn; // unset
+					pad.just_released |= btn;  // set
 				}
-				else if (state==1 && (pad.is_pressed & btn)==BTN_NONE) {
-					pad.just_pressed	|= btn; // set
-					pad.just_repeated	|= btn; // set
-					pad.is_pressed		|= btn; // set
-					pad.repeat_at[id]	= tick + PAD_REPEAT_DELAY;
+				else if (state == 1 && (pad.is_pressed & btn) == BTN_NONE)
+				{
+					pad.just_pressed |= btn;  // set
+					pad.just_repeated |= btn; // set
+					pad.is_pressed |= btn;	  // set
+					pad.repeat_at[id] = tick + PAD_REPEAT_DELAY;
 				}
 			}
 			btn = BTN_NONE; // already handled, force continue
 		}
-		else if (event.type==SDL_JOYAXISMOTION) {
+		else if (event.type == SDL_JOYAXISMOTION)
+		{
 			int axis = event.jaxis.axis;
 			int val = event.jaxis.value;
 			// LOG_info("axis: %i (%i)\n", axis,val);
-			
+
 			// triggers on tg5040
-			if (axis==AXIS_L2) {
+			if (axis == AXIS_L2)
+			{
 				btn = BTN_L2;
 				id = BTN_ID_L2;
-				pressed = val>0;
+				pressed = val > 0;
 			}
-			else if (axis==AXIS_R2) {
+			else if (axis == AXIS_R2)
+			{
 				btn = BTN_R2;
 				id = BTN_ID_R2;
-				pressed = val>0;
+				pressed = val > 0;
 			}
-			
-			else if (axis==AXIS_LX) { pad.laxis.x = val; PAD_setAnalog(BTN_ID_ANALOG_LEFT, BTN_ID_ANALOG_RIGHT, val, tick+PAD_REPEAT_DELAY); }
-			else if (axis==AXIS_LY) { pad.laxis.y = val; PAD_setAnalog(BTN_ID_ANALOG_UP,   BTN_ID_ANALOG_DOWN,  val, tick+PAD_REPEAT_DELAY); }
-			else if (axis==AXIS_RX) pad.raxis.x = val;
-			else if (axis==AXIS_RY) pad.raxis.y = val;
-			
+
+			else if (axis == AXIS_LX)
+			{
+				pad.laxis.x = val;
+				PAD_setAnalog(BTN_ID_ANALOG_LEFT, BTN_ID_ANALOG_RIGHT, val, tick + PAD_REPEAT_DELAY);
+			}
+			else if (axis == AXIS_LY)
+			{
+				pad.laxis.y = val;
+				PAD_setAnalog(BTN_ID_ANALOG_UP, BTN_ID_ANALOG_DOWN, val, tick + PAD_REPEAT_DELAY);
+			}
+			else if (axis == AXIS_RX)
+				pad.raxis.x = val;
+			else if (axis == AXIS_RY)
+				pad.raxis.y = val;
+
 			// axis will fire off what looks like a release
 			// before the first press but you can't release
 			// a button that wasn't pressed
-			if (!pressed && btn!=BTN_NONE && !(pad.is_pressed & btn)) {
+			if (!pressed && btn != BTN_NONE && !(pad.is_pressed & btn))
+			{
 				// LOG_info("cancel: %i\n", axis);
 				btn = BTN_NONE;
 			}
 		}
-		else if (event.type==SDL_QUIT) PWR_powerOff();
-		
-		if (btn==BTN_NONE) continue;
-		
-		if (!pressed) {
-			pad.is_pressed		&= ~btn; // unset
-			pad.just_repeated	&= ~btn; // unset
-			pad.just_released	|= btn; // set
+		else if (event.type == SDL_QUIT)
+			PWR_powerOff();
+
+		if (btn == BTN_NONE)
+			continue;
+
+		if (!pressed)
+		{
+			pad.is_pressed &= ~btn;	   // unset
+			pad.just_repeated &= ~btn; // unset
+			pad.just_released |= btn;  // set
 		}
-		else if ((pad.is_pressed & btn)==BTN_NONE) {
-			pad.just_pressed	|= btn; // set
-			pad.just_repeated	|= btn; // set
-			pad.is_pressed		|= btn; // set
-			pad.repeat_at[id]	= tick + PAD_REPEAT_DELAY;
+		else if ((pad.is_pressed & btn) == BTN_NONE)
+		{
+			pad.just_pressed |= btn;  // set
+			pad.just_repeated |= btn; // set
+			pad.is_pressed |= btn;	  // set
+			pad.repeat_at[id] = tick + PAD_REPEAT_DELAY;
 		}
 	}
-	
-	if (lid.has_lid && PLAT_lidChanged(NULL)) pad.just_released |= BTN_SLEEP;
+
+	if (lid.has_lid && PLAT_lidChanged(NULL))
+		pad.just_released |= BTN_SLEEP;
 }
-FALLBACK_IMPLEMENTATION int PLAT_shouldWake(void) {
+FALLBACK_IMPLEMENTATION int PLAT_shouldWake(void)
+{
 	int lid_open = 1; // assume open by default
-	if (lid.has_lid && PLAT_lidChanged(&lid_open) && lid_open) return 1;
-	
-	
+	if (lid.has_lid && PLAT_lidChanged(&lid_open) && lid_open)
+		return 1;
+
 	SDL_Event event;
-	while (SDL_PollEvent(&event)) {
-		if (event.type==SDL_KEYUP) {
+	while (SDL_PollEvent(&event))
+	{
+		if (event.type == SDL_KEYUP)
+		{
 			uint8_t code = event.key.keysym.scancode;
-			if ((BTN_WAKE==BTN_POWER && code==CODE_POWER) || (BTN_WAKE==BTN_MENU && (code==CODE_MENU || code==CODE_MENU_ALT))) {
+			if ((BTN_WAKE == BTN_POWER && code == CODE_POWER) || (BTN_WAKE == BTN_MENU && (code == CODE_MENU || code == CODE_MENU_ALT)))
+			{
 				// ignore input while lid is closed
-				if (lid.has_lid && !lid.is_open) return 0;  // do it here so we eat the input
+				if (lid.has_lid && !lid.is_open)
+					return 0; // do it here so we eat the input
 				return 1;
 			}
 		}
-		else if (event.type==SDL_JOYBUTTONUP) {
+		else if (event.type == SDL_JOYBUTTONUP)
+		{
 			uint8_t joy = event.jbutton.button;
-			if ((BTN_WAKE==BTN_POWER && joy==JOY_POWER) || (BTN_WAKE==BTN_MENU && (joy==JOY_MENU || joy==JOY_MENU_ALT))) {
+			if ((BTN_WAKE == BTN_POWER && joy == JOY_POWER) || (BTN_WAKE == BTN_MENU && (joy == JOY_MENU || joy == JOY_MENU_ALT)))
+			{
 				// ignore input while lid is closed
-				if (lid.has_lid && !lid.is_open) return 0;  // do it here so we eat the input
+				if (lid.has_lid && !lid.is_open)
+					return 0; // do it here so we eat the input
 				return 1;
 			}
-		} 
+		}
 	}
 	return 0;
 }
 
-int PAD_anyJustPressed(void)	{ return pad.just_pressed!=BTN_NONE; }
-int PAD_anyPressed(void)		{ return pad.is_pressed!=BTN_NONE; }
-int PAD_anyJustReleased(void)	{ return pad.just_released!=BTN_NONE; }
+int PAD_anyJustPressed(void) { return pad.just_pressed != BTN_NONE; }
+int PAD_anyPressed(void) { return pad.is_pressed != BTN_NONE; }
+int PAD_anyJustReleased(void) { return pad.just_released != BTN_NONE; }
 
-int PAD_justPressed(int btn)	{ return pad.just_pressed & btn; }
-int PAD_isPressed(int btn)		{ return pad.is_pressed & btn; }
-int PAD_justReleased(int btn)	{ return pad.just_released & btn; }
-int PAD_justRepeated(int btn)	{ return pad.just_repeated & btn; }
+int PAD_justPressed(int btn) { return pad.just_pressed & btn; }
+int PAD_isPressed(int btn) { return pad.is_pressed & btn; }
+int PAD_justReleased(int btn) { return pad.just_released & btn; }
+int PAD_justRepeated(int btn) { return pad.just_repeated & btn; }
 
-int PAD_tappedMenu(uint32_t now) {
-	#define MENU_DELAY 250 // also in PWR_update()
+int PAD_tappedMenu(uint32_t now)
+{
+#define MENU_DELAY 250 // also in PWR_update()
 	static uint32_t menu_start = 0;
-	static int ignore_menu = 0; 
-	if (PAD_justPressed(BTN_MENU)) {
+	static int ignore_menu = 0;
+	if (PAD_justPressed(BTN_MENU))
+	{
 		ignore_menu = 0;
 		menu_start = now;
 	}
-	else if (PAD_isPressed(BTN_MENU) && BTN_MOD_BRIGHTNESS==BTN_MENU && (PAD_justPressed(BTN_MOD_PLUS) || PAD_justPressed(BTN_MOD_MINUS))) {
+	else if (PAD_isPressed(BTN_MENU) && BTN_MOD_BRIGHTNESS == BTN_MENU && (PAD_justPressed(BTN_MOD_PLUS) || PAD_justPressed(BTN_MOD_MINUS)))
+	{
 		ignore_menu = 1;
 	}
-	return (!ignore_menu && PAD_justReleased(BTN_MENU) && now-menu_start<MENU_DELAY);
+	return (!ignore_menu && PAD_justReleased(BTN_MENU) && now - menu_start < MENU_DELAY);
 }
 
 ///////////////////////////////
 
-static struct VIB_Context {
+static struct VIB_Context
+{
 	int initialized;
 	pthread_t pt;
 	int queued_strength;
 	int strength;
 } vib = {0};
-static void* VIB_thread(void *arg) {
+static void *VIB_thread(void *arg)
+{
 #define DEFER_FRAMES 3
 	static int defer = 0;
-	while(1) {
+	while (1)
+	{
 		SDL_Delay(17);
-		if (vib.queued_strength!=vib.strength) {
-			if (defer<DEFER_FRAMES && vib.queued_strength==0) { // minimize vacillation between 0 and some number (which this motor doesn't like)
+		if (vib.queued_strength != vib.strength)
+		{
+			if (defer < DEFER_FRAMES && vib.queued_strength == 0)
+			{ // minimize vacillation between 0 and some number (which this motor doesn't like)
 				defer += 1;
 				continue;
 			}
@@ -1414,47 +1985,57 @@ static void* VIB_thread(void *arg) {
 	}
 	return 0;
 }
-void VIB_init(void) {
+void VIB_init(void)
+{
 	vib.queued_strength = vib.strength = 0;
 	pthread_create(&vib.pt, NULL, &VIB_thread, NULL);
 	vib.initialized = 1;
 }
-void VIB_quit(void) {
-	if (!vib.initialized) return;
-	
+void VIB_quit(void)
+{
+	if (!vib.initialized)
+		return;
+
 	VIB_setStrength(0);
 	pthread_cancel(vib.pt);
 	pthread_join(vib.pt, NULL);
 }
-void VIB_setStrength(int strength) {
-	if (vib.queued_strength==strength) return;
+void VIB_setStrength(int strength)
+{
+	if (vib.queued_strength == strength)
+		return;
 	vib.queued_strength = strength;
 }
-int VIB_getStrength(void) {
+int VIB_getStrength(void)
+{
 	return vib.strength;
 }
 
 ///////////////////////////////
 
-static void PWR_initOverlay(void) {
+static void PWR_initOverlay(void)
+{
 	// setup surface
 	pwr.overlay = PLAT_initOverlay();
 
 	// draw battery
-	SDLX_SetAlpha(gfx.assets, 0,0);
+	SDLX_SetAlpha(gfx.assets, 0, 0);
 	GFX_blitAsset(ASSET_BLACK_PILL, NULL, pwr.overlay, NULL);
-	SDLX_SetAlpha(gfx.assets, SDL_SRCALPHA,0);
+	SDLX_SetAlpha(gfx.assets, SDL_SRCALPHA, 0);
 	GFX_blitBattery(pwr.overlay, NULL);
 }
 
-static void PWR_updateBatteryStatus(void) {
+static void PWR_updateBatteryStatus(void)
+{
 	PLAT_getBatteryStatus(&pwr.is_charging, &pwr.charge);
-	PLAT_enableOverlay(pwr.should_warn && pwr.charge<=PWR_LOW_CHARGE);
+	PLAT_enableOverlay(pwr.should_warn && pwr.charge <= PWR_LOW_CHARGE);
 }
 
-static void* PWR_monitorBattery(void *arg) {
-	while(1) {
-		// TODO: the frequency of checking could depend on whether 
+static void *PWR_monitorBattery(void *arg)
+{
+	while (1)
+	{
+		// TODO: the frequency of checking could depend on whether
 		// we're in game (less frequent) or menu (more frequent)
 		sleep(5);
 		PWR_updateBatteryStatus();
@@ -1462,223 +2043,269 @@ static void* PWR_monitorBattery(void *arg) {
 	return NULL;
 }
 
-void PWR_init(void) {
+void PWR_init(void)
+{
 	pwr.can_sleep = 1;
 	pwr.can_poweroff = 1;
 	pwr.can_autosleep = 1;
-	
+
 	pwr.requested_sleep = 0;
 	pwr.requested_wake = 0;
-	
+
 	pwr.should_warn = 0;
 	pwr.charge = PWR_LOW_CHARGE;
-	
+
 	PWR_initOverlay();
 
 	PWR_updateBatteryStatus();
 	pthread_create(&pwr.battery_pt, NULL, &PWR_monitorBattery, NULL);
 	pwr.initialized = 1;
 }
-void PWR_quit(void) {
-	if (!pwr.initialized) return;
-	
+void PWR_quit(void)
+{
+	if (!pwr.initialized)
+		return;
+
 	PLAT_quitOverlay();
-	
+
 	// cancel battery thread
 	pthread_cancel(pwr.battery_pt);
 	pthread_join(pwr.battery_pt, NULL);
 }
-void PWR_warn(int enable) {
+void PWR_warn(int enable)
+{
 	pwr.should_warn = enable;
-	PLAT_enableOverlay(pwr.should_warn && pwr.charge<=PWR_LOW_CHARGE);
+	PLAT_enableOverlay(pwr.should_warn && pwr.charge <= PWR_LOW_CHARGE);
 }
 
-int PWR_ignoreSettingInput(int btn, int show_setting) {
-	return show_setting && (btn==BTN_MOD_PLUS || btn==BTN_MOD_MINUS);
+int PWR_ignoreSettingInput(int btn, int show_setting)
+{
+	return show_setting && (btn == BTN_MOD_PLUS || btn == BTN_MOD_MINUS);
 }
 
-void PWR_update(int* _dirty, int* _show_setting, PWR_callback_t before_sleep, PWR_callback_t after_sleep) {
+void PWR_update(int *_dirty, int *_show_setting, PWR_callback_t before_sleep, PWR_callback_t after_sleep)
+{
 	int dirty = _dirty ? *_dirty : 0;
 	int show_setting = _show_setting ? *_show_setting : 0;
-	
-	static uint32_t last_input_at = 0; // timestamp of last input (autosleep)
+
+	static uint32_t last_input_at = 0;	   // timestamp of last input (autosleep)
 	static uint32_t checked_charge_at = 0; // timestamp of last time checking charge
-	static uint32_t setting_shown_at = 0; // timestamp when settings started being shown
-	static uint32_t power_pressed_at = 0; // timestamp when power button was just pressed
-	static uint32_t mod_unpressed_at = 0; // timestamp of last time settings modifier key was NOT down
+	static uint32_t setting_shown_at = 0;  // timestamp when settings started being shown
+	static uint32_t power_pressed_at = 0;  // timestamp when power button was just pressed
+	static uint32_t mod_unpressed_at = 0;  // timestamp of last time settings modifier key was NOT down
 	static uint32_t was_muted = -1;
-	if (was_muted==-1) was_muted = GetMute();
-	
+	if (was_muted == -1)
+		was_muted = GetMute();
+
 	static int was_charging = -1;
-	if (was_charging==-1) was_charging = pwr.is_charging;
+	if (was_charging == -1)
+		was_charging = pwr.is_charging;
 
 	uint32_t now = SDL_GetTicks();
-	if (was_charging || PAD_anyPressed() || last_input_at==0) last_input_at = now;
-	
-	#define CHARGE_DELAY 1000
-	if (dirty || now-checked_charge_at>=CHARGE_DELAY) {
+	if (was_charging || PAD_anyPressed() || last_input_at == 0)
+		last_input_at = now;
+
+#define CHARGE_DELAY 1000
+	if (dirty || now - checked_charge_at >= CHARGE_DELAY)
+	{
 		int is_charging = pwr.is_charging;
-		if (was_charging!=is_charging) {
+		if (was_charging != is_charging)
+		{
 			was_charging = is_charging;
 			dirty = 1;
 		}
 		checked_charge_at = now;
 	}
-	
-	if (PAD_justReleased(BTN_POWEROFF) || (power_pressed_at && now-power_pressed_at>=1000)) {
-		if (before_sleep) before_sleep();
+
+	if (PAD_justReleased(BTN_POWEROFF) || (power_pressed_at && now - power_pressed_at >= 1000))
+	{
+		if (before_sleep)
+			before_sleep();
 		PWR_powerOff();
 	}
-	
-	if (PAD_justPressed(BTN_POWER)) {
+
+	if (PAD_justPressed(BTN_POWER))
+	{
 		power_pressed_at = now;
 	}
-	
-	#define SLEEP_DELAY 30000 // 30 seconds
-	if (now-last_input_at>=SLEEP_DELAY && PWR_preventAutosleep()) last_input_at = now;
-	
+
+#define SLEEP_DELAY 30000 // 30 seconds
+	if (now - last_input_at >= SLEEP_DELAY && PWR_preventAutosleep())
+		last_input_at = now;
+
 	if (
-		pwr.requested_sleep || // hardware requested sleep
-		now-last_input_at>=SLEEP_DELAY || // autosleep
+		pwr.requested_sleep ||						   // hardware requested sleep
+		now - last_input_at >= SLEEP_DELAY ||		   // autosleep
 		(pwr.can_sleep && PAD_justReleased(BTN_SLEEP)) // manual sleep
-	) {
+	)
+	{
 		pwr.requested_sleep = 0;
-		if (before_sleep) before_sleep();
+		if (before_sleep)
+			before_sleep();
 		PWR_fauxSleep();
-		if (after_sleep) after_sleep();
-		
+		if (after_sleep)
+			after_sleep();
+
 		last_input_at = now = SDL_GetTicks();
 		power_pressed_at = 0;
 		dirty = 1;
 	}
-	
+
 	int was_dirty = dirty; // dirty list (not including settings/battery)
-	
+
 	// TODO: only delay hiding setting changes if that setting didn't require a modifier button be held, otherwise release as soon as modifier is released
-	
-	int delay_settings = BTN_MOD_BRIGHTNESS==BTN_MENU; // when both volume and brighness require a modifier hide settings as soon as it is released
-	#define SETTING_DELAY 500
-	if (show_setting && (now-setting_shown_at>=SETTING_DELAY || !delay_settings) && !PAD_isPressed(BTN_MOD_VOLUME) && !PAD_isPressed(BTN_MOD_BRIGHTNESS)) {
+
+	int delay_settings = BTN_MOD_BRIGHTNESS == BTN_MENU; // when both volume and brighness require a modifier hide settings as soon as it is released
+#define SETTING_DELAY 500
+	if (show_setting && (now - setting_shown_at >= SETTING_DELAY || !delay_settings) && !PAD_isPressed(BTN_MOD_VOLUME) && !PAD_isPressed(BTN_MOD_BRIGHTNESS))
+	{
 		show_setting = 0;
 		dirty = 1;
 	}
-	
-	if (!show_setting && !PAD_isPressed(BTN_MOD_VOLUME) && !PAD_isPressed(BTN_MOD_BRIGHTNESS)) {
+
+	if (!show_setting && !PAD_isPressed(BTN_MOD_VOLUME) && !PAD_isPressed(BTN_MOD_BRIGHTNESS))
+	{
 		mod_unpressed_at = now; // this feels backwards but is correct
 	}
-	
-	#define MOD_DELAY 250
+
+#define MOD_DELAY 250
 	if (
 		(
-			(PAD_isPressed(BTN_MOD_VOLUME) || PAD_isPressed(BTN_MOD_BRIGHTNESS)) && 
-			(!delay_settings || now-mod_unpressed_at>=MOD_DELAY)
-		) || 
-		((!BTN_MOD_VOLUME || !BTN_MOD_BRIGHTNESS) && (PAD_justRepeated(BTN_MOD_PLUS) || PAD_justRepeated(BTN_MOD_MINUS)))
-	) {
+			(PAD_isPressed(BTN_MOD_VOLUME) || PAD_isPressed(BTN_MOD_BRIGHTNESS)) &&
+			(!delay_settings || now - mod_unpressed_at >= MOD_DELAY)) ||
+		((!BTN_MOD_VOLUME || !BTN_MOD_BRIGHTNESS) && (PAD_justRepeated(BTN_MOD_PLUS) || PAD_justRepeated(BTN_MOD_MINUS))))
+	{
 		setting_shown_at = now;
-		if (PAD_isPressed(BTN_MOD_BRIGHTNESS)) {
+		if (PAD_isPressed(BTN_MOD_BRIGHTNESS))
+		{
 			show_setting = 1;
 		}
-		else {
+		else
+		{
 			show_setting = 2;
 		}
 	}
-	
+
 	int muted = GetMute();
-	if (muted!=was_muted) {
+	if (muted != was_muted)
+	{
 		was_muted = muted;
 		show_setting = 2;
 		setting_shown_at = now;
 	}
-	
-	if (show_setting) dirty = 1; // shm is slow or keymon is catching input on the next frame
-	if (_dirty) *_dirty = dirty;
-	if (_show_setting) *_show_setting = show_setting;
+
+	if (show_setting)
+		dirty = 1; // shm is slow or keymon is catching input on the next frame
+	if (_dirty)
+		*_dirty = dirty;
+	if (_show_setting)
+		*_show_setting = show_setting;
 }
 
 // TODO: this isn't whether it can sleep but more if it should sleep in response to the sleep button
-void PWR_disableSleep(void) {
+void PWR_disableSleep(void)
+{
 	pwr.can_sleep = 0;
 }
-void PWR_enableSleep(void) {
+void PWR_enableSleep(void)
+{
 	pwr.can_sleep = 1;
 }
 
-void PWR_disablePowerOff(void) {
+void PWR_disablePowerOff(void)
+{
 	pwr.can_poweroff = 0;
 }
-void PWR_powerOff(void) {
-	if (pwr.can_poweroff) {
-		
+void PWR_powerOff(void)
+{
+	if (pwr.can_poweroff)
+	{
+
 		int w = FIXED_WIDTH;
 		int h = FIXED_HEIGHT;
 		int p = FIXED_PITCH;
-		if (GetHDMI()) {
+		if (GetHDMI())
+		{
 			w = HDMI_WIDTH;
 			h = HDMI_HEIGHT;
 			p = HDMI_PITCH;
 		}
-		gfx.screen = GFX_resize(w,h,p);
-		
-		char* msg;
-		if (HAS_POWER_BUTTON || HAS_POWEROFF_BUTTON) msg = exists(AUTO_RESUME_PATH) ? "Quicksave created,\npowering off" : "Powering off";
-		else msg = exists(AUTO_RESUME_PATH) ? "Quicksave created,\npower off now" : "Power off now";
-		
+		gfx.screen = GFX_resize(w, h, p);
+
+		char *msg;
+		if (HAS_POWER_BUTTON || HAS_POWEROFF_BUTTON)
+			msg = exists(AUTO_RESUME_PATH) ? "Quicksave created,\npowering off" : "Powering off";
+		else
+			msg = exists(AUTO_RESUME_PATH) ? "Quicksave created,\npower off now" : "Power off now";
+
 		// LOG_info("PWR_powerOff %s (%ix%i)\n", gfx.screen, gfx.screen->w, gfx.screen->h);
-		
+
 		// TODO: for some reason screen's dimensions end up being 0x0 in GFX_blitMessage...
 		PLAT_clearVideo(gfx.screen);
-		GFX_blitMessage(font.large, msg, gfx.screen,&(SDL_Rect){0,0,gfx.screen->w,gfx.screen->h}); //, NULL);
+		GFX_blitMessage(font.large, msg, gfx.screen, &(SDL_Rect){0, 0, gfx.screen->w, gfx.screen->h}); //, NULL);
 		GFX_flip(gfx.screen);
 		PLAT_powerOff();
 	}
 }
 
-static void PWR_enterSleep(void) {
+static void PWR_enterSleep(void)
+{
 	SDL_PauseAudio(1);
-	if (GetHDMI()) {
+	if (GetHDMI())
+	{
 		PLAT_clearVideo(gfx.screen);
 		PLAT_flip(gfx.screen, 0);
 	}
-	else {
+	else
+	{
 		SetRawVolume(MUTE_VOLUME_RAW);
 		PLAT_enableBacklight(0);
 	}
 	system("killall -STOP keymon.elf");
-	
+
 	sync();
 }
-static void PWR_exitSleep(void) {
+static void PWR_exitSleep(void)
+{
 	system("killall -CONT keymon.elf");
-	if (GetHDMI()) {
+	if (GetHDMI())
+	{
 		// buh
 	}
-	else {
+	else
+	{
 		PLAT_enableBacklight(1);
 		SetVolume(GetVolume());
 	}
 	SDL_PauseAudio(0);
-	
+
 	sync();
 }
 
-static void PWR_waitForWake(void) {
+static void PWR_waitForWake(void)
+{
 	uint32_t sleep_ticks = SDL_GetTicks();
-	while (!PAD_wake()) {
-		if (pwr.requested_wake) {
+	while (!PAD_wake())
+	{
+		if (pwr.requested_wake)
+		{
 			pwr.requested_wake = 0;
 			break;
 		}
 		SDL_Delay(200);
-		if (pwr.can_poweroff && SDL_GetTicks()-sleep_ticks>=120000) { // increased to two minutes
-			if (pwr.is_charging) sleep_ticks += 60000; // check again in a minute
-			else PWR_powerOff();
+		if (pwr.can_poweroff && SDL_GetTicks() - sleep_ticks >= 120000)
+		{ // increased to two minutes
+			if (pwr.is_charging)
+				sleep_ticks += 60000; // check again in a minute
+			else
+				PWR_powerOff();
 		}
 	}
-	
+
 	return;
 }
-void PWR_fauxSleep(void) {
+void PWR_fauxSleep(void)
+{
 	GFX_clear(gfx.screen);
 	PAD_reset();
 	PWR_enterSleep();
@@ -1687,30 +2314,36 @@ void PWR_fauxSleep(void) {
 	PAD_reset();
 }
 
-void PWR_disableAutosleep(void) {
+void PWR_disableAutosleep(void)
+{
 	pwr.can_autosleep = 0;
 }
-void PWR_enableAutosleep(void) {
+void PWR_enableAutosleep(void)
+{
 	pwr.can_autosleep = 1;
 }
-int PWR_preventAutosleep(void) {
+int PWR_preventAutosleep(void)
+{
 	return pwr.is_charging || !pwr.can_autosleep || GetHDMI();
 }
 
 // updated by PWR_updateBatteryStatus()
-int PWR_isCharging(void) {
+int PWR_isCharging(void)
+{
 	return pwr.is_charging;
 }
-int PWR_getBattery(void) { // 10-100 in 10-20% fragments
+int PWR_getBattery(void)
+{ // 10-100 in 10-20% fragments
 	return pwr.charge;
 }
 
 ///////////////////////////////
 
 // TODO: tmp? move to individual platforms or allow overriding like PAD_poll/PAD_wake?
-int PLAT_setDateTime(int y, int m, int d, int h, int i, int s) {
+int PLAT_setDateTime(int y, int m, int d, int h, int i, int s)
+{
 	char cmd[512];
-	sprintf(cmd, "date -s '%d-%d-%d %d:%d:%d'; hwclock --utc -w", y,m,d,h,i,s);
+	sprintf(cmd, "date -s '%d-%d-%d %d:%d:%d'; hwclock --utc -w", y, m, d, h, i, s);
 	system(cmd);
 	return 0; // why does this return an int?
 }

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -1346,7 +1346,7 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
 		// Apply crossfade at the buffer boundary
 		if (consumed > 0)
 		{
-			apply_crossfade(snd.buffer, consumed, 100);
+			apply_crossfade(snd.buffer, consumed, 200);
 		}
 
 		consumed_frames = 0;

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -1286,7 +1286,7 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
 	static double ratio = 1.0;			// Persistent ratio variable initialized to 1.0
 	static double previous_ratio = 1.0; // Store the previous ratio for smoothing
 	static double target_ratio = 1.0;	// Static target ratio for stability
-	const double smoothing_factor = 0.1;
+	const double smoothing_factor = 0.001;
 
 	if (snd.frame_count == 0)
 		return 0;
@@ -1312,12 +1312,12 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
 	if (remaining_space < (snd.frame_count / 4))
 	{
 		// Decrease target_ratio to slow down the input rate if the buffer is filling up
-		target_ratio -= 0.000000001;
+		target_ratio -= 0.00001;
 	}
 	else if (remaining_space > (3 * snd.frame_count / 4))
 	{
 		// Increase target_ratio to speed up the input rate if the buffer has enough space
-		target_ratio += 0.000000001;
+		target_ratio += 0.00001;
 	}
 
 	// Smooth the target_ratio using a simple moving average

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -1228,7 +1228,7 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
     static double ratio = 1.0; // Persistent ratio variable initialized to 1.0
     const double target_buffer_level = snd.frame_count * 0.5; // Targeting 50% buffer fill
 
-    #define BUFFER_SIZE 100
+    #define BUFFER_SIZE 5000
     static int remaining_space_buffer[BUFFER_SIZE] = {0};
     static int buffer_index = 0;
 

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -1303,8 +1303,8 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
             ratio -= adjust_step;
         }
         currentratio = ratio;
-		if(ratio < 0.99) ratio = 0.99;
-		if(ratio > 1.01) ratio = 1.01;
+		if(ratio < 0.98) ratio = 0.98;
+		if(ratio > 1.02) ratio = 1.02;
         // Write resampled frames to the buffer
         int written_frames = 0;
         pthread_mutex_lock(&audio_mutex);

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -1,9 +1,9 @@
 #ifndef __API_H__
 #define __API_H__
-#include "sdl.h"
+#include "defines.h"
 #include "platform.h"
 #include "scaler.h"
-
+#include "sdl.h"
 ///////////////////////////////
 
 enum {
@@ -21,33 +21,34 @@ void LOG_note(int level, const char* fmt, ...);
 
 ///////////////////////////////
 
-#define PAGE_COUNT	2
-#define PAGE_SCALE	3
-#define PAGE_WIDTH	(FIXED_WIDTH * PAGE_SCALE)
-#define PAGE_HEIGHT	(FIXED_HEIGHT * PAGE_SCALE)
-#define PAGE_PITCH	(PAGE_WIDTH * FIXED_BPP)
-#define PAGE_SIZE	(PAGE_PITCH * PAGE_HEIGHT)
+#define PAGE_COUNT 2
+#define PAGE_SCALE 3
+#define PAGE_WIDTH (FIXED_WIDTH * PAGE_SCALE)
+#define PAGE_HEIGHT (FIXED_HEIGHT * PAGE_SCALE)
+#define PAGE_PITCH (PAGE_WIDTH * FIXED_BPP)
+#define PAGE_SIZE (PAGE_PITCH * PAGE_HEIGHT)
 
 ///////////////////////////////
 
 // TODO: these only seem to be used by a tmp.pak in trimui (model s)
 // used by minarch, optionally defined in platform.h
 #ifndef PLAT_PAGE_BPP
-#define PLAT_PAGE_BPP 	FIXED_BPP
+#define PLAT_PAGE_BPP FIXED_BPP
 #endif
 #define PLAT_PAGE_DEPTH (PLAT_PAGE_BPP * 8)
 #define PLAT_PAGE_PITCH (PAGE_WIDTH * PLAT_PAGE_BPP)
-#define PLAT_PAGE_SIZE	(PLAT_PAGE_PITCH * PAGE_HEIGHT)
+#define PLAT_PAGE_SIZE (PLAT_PAGE_PITCH * PAGE_HEIGHT)
 
 ///////////////////////////////
 
-#define RGBA_MASK_AUTO	0x0, 0x0, 0x0, 0x0
-#define RGBA_MASK_565	0xF800, 0x07E0, 0x001F, 0x0000
-#define RGBA_MASK_8888	0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000
+#define RGBA_MASK_AUTO 0x0, 0x0, 0x0, 0x0
+#define RGBA_MASK_565 0xF800, 0x07E0, 0x001F, 0x0000
+#define RGBA_MASK_8888 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000
 
 ///////////////////////////////
 
-#define FALLBACK_IMPLEMENTATION __attribute__((weak)) // used if platform doesn't provide an implementation
+#define FALLBACK_IMPLEMENTATION \
+	__attribute__((weak))  // used if platform doesn't provide an implementation
 
 ///////////////////////////////
 
@@ -60,7 +61,6 @@ extern float currentratio;
 extern int currentbufferfree;
 extern int currentframecount;
 extern double currentfps;
- 
 
 enum {
 	ASSET_WHITE_PILL,
@@ -77,9 +77,9 @@ enum {
 	ASSET_UNDERLINE,
 	ASSET_DOT,
 	ASSET_HOLE,
-	
+
 	ASSET_COLORS,
-	
+
 	ASSET_BRIGHTNESS,
 	ASSET_VOLUME_MUTE,
 	ASSET_VOLUME,
@@ -88,20 +88,20 @@ enum {
 	ASSET_BATTERY_FILL,
 	ASSET_BATTERY_FILL_LOW,
 	ASSET_BATTERY_BOLT,
-	
+
 	ASSET_SCROLL_UP,
 	ASSET_SCROLL_DOWN,
-	
+
 	ASSET_WIFI,
-	
+
 	ASSET_COUNT,
 };
 
 typedef struct GFX_Fonts {
-	TTF_Font* large; 	// menu
-	TTF_Font* medium; 	// single char button label
-	TTF_Font* small; 	// button hint
-	TTF_Font* tiny; 	// multi char button label
+	TTF_Font* large;   // menu
+	TTF_Font* medium;  // single char button label
+	TTF_Font* small;   // button hint
+	TTF_Font* tiny;	   // multi char button label
 } GFX_Fonts;
 extern GFX_Fonts font;
 
@@ -122,9 +122,10 @@ typedef struct GFX_Renderer {
 	void* src;
 	void* dst;
 	void* blit;
-	double aspect; // 0 for integer, -1 for fullscreen, otherwise aspect ratio, used for SDL2 accelerated scaling
+	double aspect;	// 0 for integer, -1 for fullscreen, otherwise aspect ratio,
+					// used for SDL2 accelerated scaling
 	int scale;
-	
+
 	// TODO: document this better
 	int true_w;
 	int true_h;
@@ -134,7 +135,7 @@ typedef struct GFX_Renderer {
 	int src_w;
 	int src_h;
 	int src_p;
-	
+
 	// TODO: I think this is overscaled
 	int dst_x;
 	int dst_y;
@@ -149,34 +150,37 @@ enum {
 };
 
 SDL_Surface* GFX_init(int mode);
-#define GFX_resize PLAT_resizeVideo // (int w, int h, int pitch);
-#define GFX_setScaleClip PLAT_setVideoScaleClip // (int x, int y, int width, int height)
-#define GFX_setNearestNeighbor PLAT_setNearestNeighbor // (int enabled)
-#define GFX_setSharpness PLAT_setSharpness // (int sharpness)
-#define GFX_setEffectColor PLAT_setEffectColor // (int color)
-#define GFX_setEffect PLAT_setEffect // (int effect)
+#define GFX_resize PLAT_resizeVideo	 // (int w, int h, int pitch);
+#define GFX_setScaleClip \
+	PLAT_setVideoScaleClip	// (int x, int y, int width, int height)
+#define GFX_setNearestNeighbor PLAT_setNearestNeighbor	// (int enabled)
+#define GFX_setSharpness PLAT_setSharpness				// (int sharpness)
+#define GFX_setEffectColor PLAT_setEffectColor			// (int color)
+#define GFX_setEffect PLAT_setEffect					// (int effect)
 void GFX_setMode(int mode);
 int GFX_hdmiChanged(void);
 
-#define GFX_clear PLAT_clearVideo // (SDL_Surface* screen)
-#define GFX_clearAll PLAT_clearAll // (void)
+#define GFX_clear PLAT_clearVideo	// (SDL_Surface* screen)
+#define GFX_clearAll PLAT_clearAll	// (void)
 
 void GFX_startFrame(void);
 void GFX_flip(SDL_Surface* screen);
-#define GFX_supportsOverscan PLAT_supportsOverscan // (void)
-void GFX_sync(void); // call this to maintain 60fps when not calling GFX_flip() this frame
+#define GFX_supportsOverscan PLAT_supportsOverscan	// (void)
+void GFX_sync(void);  // call this to maintain 60fps when not calling GFX_flip()
+					  // this frame
 void GFX_quit(void);
 
 enum {
 	VSYNC_OFF = 0,
-	VSYNC_LENIENT, // default
+	VSYNC_LENIENT,	// default
 	VSYNC_STRICT,
 };
 
 int GFX_getVsync(void);
 void GFX_setVsync(int vsync);
 
-int GFX_truncateText(TTF_Font* font, const char* in_name, char* out_name, int max_width, int padding); // returns final width
+int GFX_truncateText(TTF_Font* font, const char* in_name, char* out_name,
+					 int max_width, int padding);  // returns final width
 int GFX_wrapText(TTF_Font* font, char* str, int max_width, int max_lines);
 
 #define GFX_getScaler PLAT_getScaler		// scaler_t:(GFX_Renderer* renderer)
@@ -186,20 +190,25 @@ scaler_t GFX_getAAScaler(GFX_Renderer* renderer);
 void GFX_freeAAScaler(void);
 
 // NOTE: all dimensions should be pre-scaled
-void GFX_blitAsset(int asset, SDL_Rect* src_rect, SDL_Surface* dst, SDL_Rect* dst_rect);
+void GFX_blitAsset(int asset, SDL_Rect* src_rect, SDL_Surface* dst,
+				   SDL_Rect* dst_rect);
 void GFX_blitPill(int asset, SDL_Surface* dst, SDL_Rect* dst_rect);
 void GFX_blitRect(int asset, SDL_Surface* dst, SDL_Rect* dst_rect);
 void GFX_blitBattery(SDL_Surface* dst, SDL_Rect* dst_rect);
 int GFX_getButtonWidth(char* hint, char* button);
-void GFX_blitButton(char* hint, char*button, SDL_Surface* dst, SDL_Rect* dst_rect);
-void GFX_blitMessage(TTF_Font* font, char* msg, SDL_Surface* dst, SDL_Rect* dst_rect);
+void GFX_blitButton(char* hint, char* button, SDL_Surface* dst,
+					SDL_Rect* dst_rect);
+void GFX_blitMessage(TTF_Font* font, char* msg, SDL_Surface* dst,
+					 SDL_Rect* dst_rect);
 
 int GFX_blitHardwareGroup(SDL_Surface* dst, int show_setting);
 void GFX_blitHardwareHints(SDL_Surface* dst, int show_setting);
-int GFX_blitButtonGroup(char** hints, int primary, SDL_Surface* dst, int align_right);
+int GFX_blitButtonGroup(char** hints, int primary, SDL_Surface* dst,
+						int align_right);
 
 void GFX_sizeText(TTF_Font* font, char* str, int leading, int* w, int* h);
-void GFX_blitText(TTF_Font* font, char* str, int leading, SDL_Color color, SDL_Surface* dst, SDL_Rect* dst_rect);
+void GFX_blitText(TTF_Font* font, char* str, int leading, SDL_Color color,
+				  SDL_Surface* dst, SDL_Rect* dst_rect);
 
 ///////////////////////////////
 
@@ -208,8 +217,8 @@ typedef struct SND_Frame {
 	int16_t right;
 } SND_Frame;
 typedef struct {
-    SND_Frame *frames;
-    int frame_count;
+	SND_Frame* frames;
+	int frame_count;
 } ResampledFrames;
 
 void SND_init(double sample_rate, double frame_rate);
@@ -230,8 +239,8 @@ int PLAT_lidChanged(int* state);
 ///////////////////////////////
 
 typedef struct PAD_Axis {
-		int x;
-		int y;
+	int x;
+	int y;
 } PAD_Axis;
 typedef struct PAD_Context {
 	int is_pressed;
@@ -244,7 +253,7 @@ typedef struct PAD_Context {
 } PAD_Context;
 extern PAD_Context pad;
 
-#define PAD_REPEAT_DELAY	300
+#define PAD_REPEAT_DELAY 300
 #define PAD_REPEAT_INTERVAL 100
 
 #define PAD_init PLAT_initInput
@@ -252,7 +261,7 @@ extern PAD_Context pad;
 #define PAD_poll PLAT_pollInput
 #define PAD_wake PLAT_shouldWake
 
-void PAD_setAnalog(int neg, int pos, int value, int repeat_at); // internal
+void PAD_setAnalog(int neg, int pos, int value, int repeat_at);	 // internal
 
 void PAD_reset(void);
 int PAD_anyJustPressed(void);
@@ -264,18 +273,20 @@ int PAD_isPressed(int btn);
 int PAD_justReleased(int btn);
 int PAD_justRepeated(int btn);
 
-int PAD_tappedMenu(uint32_t now); // special case, returns 1 on release of BTN_MENU within 250ms if BTN_PLUS/BTN_MINUS haven't been pressed
+int PAD_tappedMenu(
+	uint32_t now);	// special case, returns 1 on release of BTN_MENU within
+					// 250ms if BTN_PLUS/BTN_MINUS haven't been pressed
 
 ///////////////////////////////
 
 void VIB_init(void);
 void VIB_quit(void);
 void VIB_setStrength(int strength);
- int VIB_getStrength(void);
-	
+int VIB_getStrength(void);
+
 ///////////////////////////////
 
-#define BRIGHTNESS_BUTTON_LABEL "+ -" // ew
+#define BRIGHTNESS_BUTTON_LABEL "+ -"  // ew
 
 typedef void (*PWR_callback_t)(void);
 void PWR_init(void);
@@ -283,7 +294,8 @@ void PWR_quit(void);
 void PWR_warn(int enable);
 
 int PWR_ignoreSettingInput(int btn, int show_setting);
-void PWR_update(int* dirty, int* show_setting, PWR_callback_t before_sleep, PWR_callback_t after_sleep);
+void PWR_update(int* dirty, int* show_setting, PWR_callback_t before_sleep,
+				PWR_callback_t after_sleep);
 
 void PWR_disablePowerOff(void);
 void PWR_powerOff(void);
@@ -336,13 +348,14 @@ int PLAT_supportsOverscan(void);
 SDL_Surface* PLAT_initOverlay(void);
 void PLAT_quitOverlay(void);
 void PLAT_enableOverlay(int enable);
-	
+
 #define PWR_LOW_CHARGE 10
-void PLAT_getBatteryStatus(int* is_charging, int* charge); // 0,1 and 0,10,20,40,60,80,100
+void PLAT_getBatteryStatus(int* is_charging,
+						   int* charge);  // 0,1 and 0,10,20,40,60,80,100
 void PLAT_enableBacklight(int enable);
 void PLAT_powerOff(void);
-	
-void PLAT_setCPUSpeed(int speed); // enum
+
+void PLAT_setCPUSpeed(int speed);  // enum
 void PLAT_setRumble(int strength);
 int PLAT_pickSampleRate(int requested, int max);
 

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -59,6 +59,7 @@ extern uint32_t RGB_DARK_GRAY;
 extern float currentratio;
 extern int currentbufferfree;
 extern int currentframecount;
+extern double currentfps;
  
 
 enum {

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -56,6 +56,10 @@ extern uint32_t RGB_BLACK;
 extern uint32_t RGB_LIGHT_GRAY;
 extern uint32_t RGB_GRAY;
 extern uint32_t RGB_DARK_GRAY;
+extern float currentratio;
+extern int currentbufferfree;
+extern int currentframecount;
+ 
 
 enum {
 	ASSET_WHITE_PILL,

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -202,6 +202,10 @@ typedef struct SND_Frame {
 	int16_t left;
 	int16_t right;
 } SND_Frame;
+typedef struct {
+    SND_Frame *frames;
+    int frame_count;
+} ResampledFrames;
 
 void SND_init(double sample_rate, double frame_rate);
 size_t SND_batchSamples(const SND_Frame* frames, size_t frame_count);

--- a/workspace/all/common/defines.h
+++ b/workspace/all/common/defines.h
@@ -3,10 +3,10 @@
 
 #include "platform.h"
 
-#define VOLUME_MIN 		0
-#define VOLUME_MAX 		20
-#define BRIGHTNESS_MIN 	0
-#define BRIGHTNESS_MAX 	10
+#define VOLUME_MIN 0
+#define VOLUME_MAX 20
+#define BRIGHTNESS_MIN 0
+#define BRIGHTNESS_MAX 10
 
 #define MAX_PATH 512
 
@@ -26,47 +26,57 @@
 #define FAUX_RECENT_PATH SDCARD_PATH "/Recently Played"
 #define COLLECTIONS_PATH SDCARD_PATH "/Collections"
 
-#define LAST_PATH "/tmp/last.txt" // transient
+#define LAST_PATH "/tmp/last.txt"  // transient
 #define CHANGE_DISC_PATH "/tmp/change_disc.txt"
 #define RESUME_SLOT_PATH "/tmp/resume_slot.txt"
 #define NOUI_PATH "/tmp/noui"
 
-#define TRIAD_WHITE 		0xff,0xff,0xff
-#define TRIAD_BLACK 		0x00,0x00,0x00
-#define TRIAD_LIGHT_GRAY 	0x7f,0x7f,0x7f
-#define TRIAD_GRAY 			0x99,0x99,0x99
-#define TRIAD_DARK_GRAY 	0x26,0x26,0x26
+#define TRIAD_WHITE 0xff, 0xff, 0xff
+#define TRIAD_BLACK 0x00, 0x00, 0x00
+#define TRIAD_LIGHT_GRAY 0x7f, 0x7f, 0x7f
+#define TRIAD_GRAY 0x99, 0x99, 0x99
+#define TRIAD_DARK_GRAY 0x26, 0x26, 0x26
 
-#define TRIAD_LIGHT_TEXT 	0xcc,0xcc,0xcc
-#define TRIAD_DARK_TEXT 	0x66,0x66,0x66
+#define TRIAD_LIGHT_TEXT 0xcc, 0xcc, 0xcc
+#define TRIAD_DARK_TEXT 0x66, 0x66, 0x66
 
-#define COLOR_WHITE			(SDL_Color){TRIAD_WHITE}
-#define COLOR_GRAY			(SDL_Color){TRIAD_GRAY}
-#define COLOR_BLACK			(SDL_Color){TRIAD_BLACK}
-#define COLOR_LIGHT_TEXT	(SDL_Color){TRIAD_LIGHT_TEXT}
-#define COLOR_DARK_TEXT		(SDL_Color){TRIAD_DARK_TEXT}
-#define COLOR_BUTTON_TEXT	(SDL_Color){TRIAD_GRAY}
+#define COLOR_WHITE \
+	(SDL_Color) { TRIAD_WHITE }
+#define COLOR_GRAY \
+	(SDL_Color) { TRIAD_GRAY }
+#define COLOR_BLACK \
+	(SDL_Color) { TRIAD_BLACK }
+#define COLOR_LIGHT_TEXT \
+	(SDL_Color) { TRIAD_LIGHT_TEXT }
+#define COLOR_DARK_TEXT \
+	(SDL_Color) { TRIAD_DARK_TEXT }
+#define COLOR_BUTTON_TEXT \
+	(SDL_Color) { TRIAD_GRAY }
 
 // all before scale
 #define PILL_SIZE 30
 #define BUTTON_SIZE 20
-#define BUTTON_MARGIN 5 // ((PILL_SIZE - BUTTON_SIZE) / 2)
+#define BUTTON_MARGIN 5	 // ((PILL_SIZE - BUTTON_SIZE) / 2)
 #define BUTTON_PADDING 12
 #define SETTINGS_SIZE 4
 #define SETTINGS_WIDTH 80
 
 #ifndef MAIN_ROW_COUNT
-#define MAIN_ROW_COUNT 6 // FIXED_HEIGHT / (PILL_SIZE * FIXED_SCALE) - 2 (floor and subtract 1 if not an integer)
+#define MAIN_ROW_COUNT \
+	6  // FIXED_HEIGHT / (PILL_SIZE * FIXED_SCALE) - 2 (floor and subtract 1 if
+	   // not an integer)
 #endif
 
 #ifndef PADDING
-#define PADDING 10 // PILL_SIZE / 3 (or non-integer part of the previous calculatiom divided by three)
+#define PADDING \
+	10	// PILL_SIZE / 3 (or non-integer part of the previous calculatiom
+		// divided by three)
 #endif
 
-#define FONT_LARGE 16 	// menu
-#define FONT_MEDIUM 14 	// single char button label
-#define FONT_SMALL 12 	// button hint
-#define FONT_TINY 10  	// multi char button label
+#define FONT_LARGE 16	// menu
+#define FONT_MEDIUM 14	// single char button label
+#define FONT_SMALL 12	// button hint
+#define FONT_TINY 10	// multi char button label
 
 ///////////////////////////////
 
@@ -75,26 +85,31 @@
 
 #define MAX(a, b) (a) > (b) ? (a) : (b)
 #define MIN(a, b) (a) < (b) ? (a) : (b)
-#define CEIL_DIV(a,b) ((a) + (b) - 1) / (b)
+#define CEIL_DIV(a, b) ((a) + (b) - 1) / (b)
 
-#define SCALE1(a) ((a)*FIXED_SCALE)
-#define SCALE2(a,b) ((a)*FIXED_SCALE),((b)*FIXED_SCALE)
-#define SCALE3(a,b,c) ((a)*FIXED_SCALE),((b)*FIXED_SCALE),((c)*FIXED_SCALE)
-#define SCALE4(a,b,c,d) ((a)*FIXED_SCALE),((b)*FIXED_SCALE),((c)*FIXED_SCALE),((d)*FIXED_SCALE)
-
-///////////////////////////////
-
-#define HAS_POWER_BUTTON (BUTTON_POWER!=BUTTON_NA||CODE_POWER!=CODE_NA||JOY_POWER!=JOY_NA)
-#define HAS_POWEROFF_BUTTON (BUTTON_POWEROFF!=BUTTON_NA)
-#define HAS_MENU_BUTTON (BUTTON_MENU!=BUTTON_NA||CODE_MENU!=CODE_NA||JOY_MENU!=JOY_NA)
-#define HAS_SKINNY_SCREEN (FIXED_WIDTH<320)
+#define SCALE1(a) ((a) * FIXED_SCALE)
+#define SCALE2(a, b) ((a) * FIXED_SCALE), ((b) * FIXED_SCALE)
+#define SCALE3(a, b, c) \
+	((a) * FIXED_SCALE), ((b) * FIXED_SCALE), ((c) * FIXED_SCALE)
+#define SCALE4(a, b, c, d)                                         \
+	((a) * FIXED_SCALE), ((b) * FIXED_SCALE), ((c) * FIXED_SCALE), \
+		((d) * FIXED_SCALE)
 
 ///////////////////////////////
 
-#define BUTTON_NA	-1
-#define CODE_NA		-1
-#define JOY_NA		-1
-#define AXIS_NA		-1
+#define HAS_POWER_BUTTON \
+	(BUTTON_POWER != BUTTON_NA || CODE_POWER != CODE_NA || JOY_POWER != JOY_NA)
+#define HAS_POWEROFF_BUTTON (BUTTON_POWEROFF != BUTTON_NA)
+#define HAS_MENU_BUTTON \
+	(BUTTON_MENU != BUTTON_NA || CODE_MENU != CODE_NA || JOY_MENU != JOY_NA)
+#define HAS_SKINNY_SCREEN (FIXED_WIDTH < 320)
+
+///////////////////////////////
+
+#define BUTTON_NA -1
+#define CODE_NA -1
+#define JOY_NA -1
+#define AXIS_NA -1
 
 #ifndef BUTTON_POWEROFF
 #define BUTTON_POWEROFF BUTTON_NA
@@ -118,25 +133,25 @@
 #endif
 
 #ifndef AXIS_L2
-#define AXIS_L2	AXIS_NA
-#define AXIS_R2	AXIS_NA
-#endif 
-
-#ifndef AXIS_LX
-#define AXIS_LX	AXIS_NA
-#define AXIS_LY	AXIS_NA
-#define AXIS_RX	AXIS_NA
-#define AXIS_RY	AXIS_NA
-#endif 
-
-#ifndef HAS_HDMI
-#define HDMI_WIDTH	FIXED_WIDTH
-#define HDMI_HEIGHT	FIXED_HEIGHT
-#define HDMI_PITCH	FIXED_PITCH
-#define HDMI_SIZE	FIXED_SIZE
+#define AXIS_L2 AXIS_NA
+#define AXIS_R2 AXIS_NA
 #endif
 
-#ifndef BTN_A // prevent collisions with input.h in keymon
+#ifndef AXIS_LX
+#define AXIS_LX AXIS_NA
+#define AXIS_LY AXIS_NA
+#define AXIS_RX AXIS_NA
+#define AXIS_RY AXIS_NA
+#endif
+
+#ifndef HAS_HDMI
+#define HDMI_WIDTH FIXED_WIDTH
+#define HDMI_HEIGHT FIXED_HEIGHT
+#define HDMI_PITCH FIXED_PITCH
+#define HDMI_SIZE FIXED_SIZE
+#endif
+
+#ifndef BTN_A  // prevent collisions with input.h in keymon
 // TODO: doesn't this belong in api.h? it's meaningless without PAD_*
 enum {
 	BTN_ID_NONE = -1,
@@ -159,7 +174,7 @@ enum {
 	BTN_ID_MENU,
 	BTN_ID_PLUS,
 	BTN_ID_MINUS,
-	BTN_ID_POWER,	
+	BTN_ID_POWER,
 	BTN_ID_POWEROFF,
 
 	BTN_ID_ANALOG_UP,
@@ -170,38 +185,38 @@ enum {
 	BTN_ID_COUNT,
 };
 enum {
-	BTN_NONE		= 0,
-	BTN_DPAD_UP 	= 1 << BTN_ID_DPAD_UP,
-	BTN_DPAD_DOWN	= 1 << BTN_ID_DPAD_DOWN,
-	BTN_DPAD_LEFT	= 1 << BTN_ID_DPAD_LEFT,
-	BTN_DPAD_RIGHT	= 1 << BTN_ID_DPAD_RIGHT,
-	BTN_A			= 1 << BTN_ID_A,
-	BTN_B			= 1 << BTN_ID_B,
-	BTN_X			= 1 << BTN_ID_X,
-	BTN_Y			= 1 << BTN_ID_Y,
-	BTN_START		= 1 << BTN_ID_START,
-	BTN_SELECT		= 1 << BTN_ID_SELECT,
-	BTN_L1			= 1 << BTN_ID_L1,
-	BTN_R1			= 1 << BTN_ID_R1,
-	BTN_L2			= 1 << BTN_ID_L2,
-	BTN_R2			= 1 << BTN_ID_R2,
-	BTN_L3			= 1 << BTN_ID_L3,
-	BTN_R3			= 1 << BTN_ID_R3,
-	BTN_MENU		= 1 << BTN_ID_MENU,
-	BTN_PLUS		= 1 << BTN_ID_PLUS,
-	BTN_MINUS		= 1 << BTN_ID_MINUS,
-	BTN_POWER		= 1 << BTN_ID_POWER,
-	BTN_POWEROFF	= 1 << BTN_ID_POWEROFF,
+	BTN_NONE = 0,
+	BTN_DPAD_UP = 1 << BTN_ID_DPAD_UP,
+	BTN_DPAD_DOWN = 1 << BTN_ID_DPAD_DOWN,
+	BTN_DPAD_LEFT = 1 << BTN_ID_DPAD_LEFT,
+	BTN_DPAD_RIGHT = 1 << BTN_ID_DPAD_RIGHT,
+	BTN_A = 1 << BTN_ID_A,
+	BTN_B = 1 << BTN_ID_B,
+	BTN_X = 1 << BTN_ID_X,
+	BTN_Y = 1 << BTN_ID_Y,
+	BTN_START = 1 << BTN_ID_START,
+	BTN_SELECT = 1 << BTN_ID_SELECT,
+	BTN_L1 = 1 << BTN_ID_L1,
+	BTN_R1 = 1 << BTN_ID_R1,
+	BTN_L2 = 1 << BTN_ID_L2,
+	BTN_R2 = 1 << BTN_ID_R2,
+	BTN_L3 = 1 << BTN_ID_L3,
+	BTN_R3 = 1 << BTN_ID_R3,
+	BTN_MENU = 1 << BTN_ID_MENU,
+	BTN_PLUS = 1 << BTN_ID_PLUS,
+	BTN_MINUS = 1 << BTN_ID_MINUS,
+	BTN_POWER = 1 << BTN_ID_POWER,
+	BTN_POWEROFF = 1 << BTN_ID_POWEROFF,
 
-	BTN_ANALOG_UP 	= 1 << BTN_ID_ANALOG_UP,
-	BTN_ANALOG_DOWN	= 1 << BTN_ID_ANALOG_DOWN,
-	BTN_ANALOG_LEFT	= 1 << BTN_ID_ANALOG_LEFT,
-	BTN_ANALOG_RIGHT= 1 << BTN_ID_ANALOG_RIGHT,
-	
-	BTN_UP 		= BTN_DPAD_UP | BTN_ANALOG_UP,
-	BTN_DOWN 	= BTN_DPAD_DOWN | BTN_ANALOG_DOWN,
-	BTN_LEFT	= BTN_DPAD_LEFT | BTN_ANALOG_LEFT,
-	BTN_RIGHT	= BTN_DPAD_RIGHT | BTN_ANALOG_RIGHT,
+	BTN_ANALOG_UP = 1 << BTN_ID_ANALOG_UP,
+	BTN_ANALOG_DOWN = 1 << BTN_ID_ANALOG_DOWN,
+	BTN_ANALOG_LEFT = 1 << BTN_ID_ANALOG_LEFT,
+	BTN_ANALOG_RIGHT = 1 << BTN_ID_ANALOG_RIGHT,
+
+	BTN_UP = BTN_DPAD_UP | BTN_ANALOG_UP,
+	BTN_DOWN = BTN_DPAD_DOWN | BTN_ANALOG_DOWN,
+	BTN_LEFT = BTN_DPAD_LEFT | BTN_ANALOG_LEFT,
+	BTN_RIGHT = BTN_DPAD_RIGHT | BTN_ANALOG_RIGHT,
 };
 #endif
 

--- a/workspace/all/minarch/makefile
+++ b/workspace/all/minarch/makefile
@@ -27,7 +27,7 @@ CC = $(CROSS_COMPILE)gcc
 CFLAGS   = $(ARCH) -fomit-frame-pointer
 CFLAGS  += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DUSE_$(SDL) -Ofast -std=gnu99
 CFLAGS	+= -Os -flto
-LDFLAGS	 = -ldl $(LIBS) -lmsettings -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
+LDFLAGS	 = -ldl $(LIBS) -lmsettings -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz /usr/lib/aarch64-linux-gnu/libsamplerate.a
 # CFLAGS  += -Wall -Wno-unused-variable -Wno-unused-function -Wno-format-overflow
 # CFLAGS  += -fsanitize=address -fno-common
 # LDFLAGS += -lasan

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -1,23 +1,22 @@
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <msettings.h>
+#include <pthread.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <msettings.h>
-
-#include <unistd.h>
-#include <fcntl.h>
-#include <dlfcn.h>
-#include <libgen.h>
-#include <time.h>
 #include <sys/stat.h>
-#include <errno.h>
+#include <time.h>
+#include <unistd.h>
 #include <zlib.h>
-#include <pthread.h>
 
-#include "libretro.h"
-#include "defines.h"
 #include "api.h"
-#include "utils.h"
+#include "defines.h"
+#include "libretro.h"
 #include "scaler.h"
+#include "utils.h"
 
 ///////////////////////////////////////
 
@@ -27,13 +26,13 @@ static int show_menu = 0;
 static int simple_mode = 0;
 static int thread_video = 0;
 static int was_threaded = 0;
-static int should_run_core = 1; // used by threaded video
+static int should_run_core = 1;	 // used by threaded video
 
-static pthread_t		core_pt;
-static pthread_mutex_t	core_mx;
-static pthread_cond_t	core_rq; // not sure this is required
-static SDL_Surface*	backbuffer = NULL;
-static void* coreThread(void *arg);
+static pthread_t core_pt;
+static pthread_mutex_t core_mx;
+static pthread_cond_t core_rq;	// not sure this is required
+static SDL_Surface* backbuffer = NULL;
+static void* coreThread(void* arg);
 
 enum {
 	SCALE_NATIVE,
@@ -47,19 +46,20 @@ enum {
 static int screen_scaling = SCALE_ASPECT;
 static int screen_sharpness = SHARPNESS_SOFT;
 static int screen_effect = EFFECT_NONE;
-static int prevent_tearing = 1; // lenient
+static int prevent_tearing = 1;	 // lenient
 static int show_debug = 0;
-static int max_ff_speed = 3; // 4x
+static int max_ff_speed = 3;  // 4x
 static int fast_forward = 0;
-static int overclock = 1; // normal
+static int overclock = 1;  // normal
 static int has_custom_controllers = 0;
-static int gamepad_type = 0; // index in gamepad_labels/gamepad_values
-static int downsample = 0; // set to 1 to convert from 8888 to 565
+static int gamepad_type = 0;  // index in gamepad_labels/gamepad_values
+static int downsample = 0;	  // set to 1 to convert from 8888 to 565
 
-// these are no longer constants as of the RG CubeXX (even though they look like it)
-static int DEVICE_WIDTH = 0; // FIXED_WIDTH;
-static int DEVICE_HEIGHT = 0; // FIXED_HEIGHT;
-static int DEVICE_PITCH = 0; // FIXED_PITCH;
+// these are no longer constants as of the RG CubeXX (even though they look like
+// it)
+static int DEVICE_WIDTH = 0;   // FIXED_WIDTH;
+static int DEVICE_HEIGHT = 0;  // FIXED_HEIGHT;
+static int DEVICE_PITCH = 0;   // FIXED_PITCH;
 
 GFX_Renderer renderer;
 
@@ -68,41 +68,45 @@ GFX_Renderer renderer;
 static struct Core {
 	int initialized;
 	int need_fullpath;
-	
-	const char tag[8]; // eg. GBC
-	const char name[128]; // eg. gambatte
-	const char version[128]; // eg. Gambatte (v0.5.0-netlink 7e02df6)
-	const char extensions[128]; // eg. gb|gbc|dmg
-	
-	const char config_dir[MAX_PATH]; // eg. /mnt/sdcard/.userdata/rg35xx/GB-gambatte
-	const char states_dir[MAX_PATH]; // eg. /mnt/sdcard/.userdata/arm-480/GB-gambatte
-	const char saves_dir[MAX_PATH]; // eg. /mnt/sdcard/Saves/GB
-	const char bios_dir[MAX_PATH]; // eg. /mnt/sdcard/Bios/GB
-	
+
+	const char tag[8];			 // eg. GBC
+	const char name[128];		 // eg. gambatte
+	const char version[128];	 // eg. Gambatte (v0.5.0-netlink 7e02df6)
+	const char extensions[128];	 // eg. gb|gbc|dmg
+
+	const char
+		config_dir[MAX_PATH];  // eg. /mnt/sdcard/.userdata/rg35xx/GB-gambatte
+	const char
+		states_dir[MAX_PATH];  // eg. /mnt/sdcard/.userdata/arm-480/GB-gambatte
+	const char saves_dir[MAX_PATH];	 // eg. /mnt/sdcard/Saves/GB
+	const char bios_dir[MAX_PATH];	 // eg. /mnt/sdcard/Bios/GB
+
 	double fps;
 	double sample_rate;
 	double aspect_ratio;
-	
+
 	void* handle;
 	void (*init)(void);
 	void (*deinit)(void);
-	
-	void (*get_system_info)(struct retro_system_info *info);
-	void (*get_system_av_info)(struct retro_system_av_info *info);
+
+	void (*get_system_info)(struct retro_system_info* info);
+	void (*get_system_av_info)(struct retro_system_av_info* info);
 	void (*set_controller_port_device)(unsigned port, unsigned device);
-	
+
 	void (*reset)(void);
 	void (*run)(void);
 	size_t (*serialize_size)(void);
-	bool (*serialize)(void *data, size_t size);
-	bool (*unserialize)(const void *data, size_t size);
-	bool (*load_game)(const struct retro_game_info *game);
-	bool (*load_game_special)(unsigned game_type, const struct retro_game_info *info, size_t num_info);
+	bool (*serialize)(void* data, size_t size);
+	bool (*unserialize)(const void* data, size_t size);
+	bool (*load_game)(const struct retro_game_info* game);
+	bool (*load_game_special)(unsigned game_type,
+							  const struct retro_game_info* info,
+							  size_t num_info);
 	void (*unload_game)(void);
 	unsigned (*get_region)(void);
-	void *(*get_memory_data)(unsigned id);
+	void* (*get_memory_data)(unsigned id);
 	size_t (*get_memory_size)(unsigned id);
-	
+
 	// retro_audio_buffer_status_callback_t audio_buffer_status;
 } core;
 
@@ -111,31 +115,33 @@ static struct Core {
 
 #define ZIP_HEADER_SIZE 30
 #define ZIP_CHUNK_SIZE 65536
-#define ZIP_LE_READ16(buf) ((uint16_t)(((uint8_t *)(buf))[1] << 8 | ((uint8_t *)(buf))[0]))
-#define ZIP_LE_READ32(buf) ((uint32_t)(((uint8_t *)(buf))[3] << 24 | ((uint8_t *)(buf))[2] << 16 | ((uint8_t *)(buf))[1] << 8 | ((uint8_t *)(buf))[0]))
+#define ZIP_LE_READ16(buf) \
+	((uint16_t)(((uint8_t*)(buf))[1] << 8 | ((uint8_t*)(buf))[0]))
+#define ZIP_LE_READ32(buf)                                                \
+	((uint32_t)(((uint8_t*)(buf))[3] << 24 | ((uint8_t*)(buf))[2] << 16 | \
+				((uint8_t*)(buf))[1] << 8 | ((uint8_t*)(buf))[0]))
 typedef int (*Zip_extract_t)(FILE* zip, FILE* dst, size_t size);
 
-static int Zip_copy(FILE* zip, FILE* dst, size_t size) { // uncompressed?
+static int Zip_copy(FILE* zip, FILE* dst, size_t size) {  // uncompressed?
 	uint8_t buffer[ZIP_CHUNK_SIZE];
 	while (size) {
 		size_t sz = MIN(size, ZIP_CHUNK_SIZE);
-		if (sz!= fread(buffer, 1, sz, zip)) return -1;
-		if (sz!=fwrite(buffer, 1, sz, dst)) return -1;
+		if (sz != fread(buffer, 1, sz, zip)) return -1;
+		if (sz != fwrite(buffer, 1, sz, dst)) return -1;
 		size -= sz;
 	}
 	return 0;
 }
-static int Zip_inflate(FILE* zip, FILE* dst, size_t size) { // compressed
+static int Zip_inflate(FILE* zip, FILE* dst, size_t size) {	 // compressed
 	z_stream stream = {0};
 	size_t have = 0;
-	uint8_t  in[ZIP_CHUNK_SIZE];
+	uint8_t in[ZIP_CHUNK_SIZE];
 	uint8_t out[ZIP_CHUNK_SIZE];
 	int ret = -1;
 
 	ret = inflateInit2(&stream, -MAX_WBITS);
-	if (ret != Z_OK)
-		return ret;
-	
+	if (ret != Z_OK) return ret;
+
 	do {
 		size_t insize = MIN(size, ZIP_CHUNK_SIZE);
 
@@ -145,8 +151,7 @@ static int Zip_inflate(FILE* zip, FILE* dst, size_t size) { // compressed
 			return Z_ERRNO;
 		}
 
-		if (!stream.avail_in)
-			break;
+		if (!stream.avail_in) break;
 		stream.next_in = in;
 
 		do {
@@ -154,7 +159,7 @@ static int Zip_inflate(FILE* zip, FILE* dst, size_t size) { // compressed
 			stream.next_out = out;
 
 			ret = inflate(&stream, Z_NO_FLUSH);
-			switch(ret) {
+			switch (ret) {
 				case Z_NEED_DICT:
 					ret = Z_DATA_ERROR;
 				case Z_DATA_ERROR:
@@ -186,9 +191,9 @@ static int Zip_inflate(FILE* zip, FILE* dst, size_t size) { // compressed
 
 static struct Game {
 	char path[MAX_PATH];
-	char name[MAX_PATH]; // TODO: rename to basename?
+	char name[MAX_PATH];  // TODO: rename to basename?
 	char m3u_path[MAX_PATH];
-	char tmp_path[MAX_PATH]; // location of unzipped file
+	char tmp_path[MAX_PATH];  // location of unzipped file
 	void* data;
 	size_t size;
 	int is_open;
@@ -196,10 +201,10 @@ static struct Game {
 static void Game_open(char* path) {
 	LOG_info("Game_open\n");
 	memset(&game, 0, sizeof(game));
-	
+
 	strcpy((char*)game.path, path);
-	strcpy((char*)game.name, strrchr(path, '/')+1);
-	
+	strcpy((char*)game.name, strrchr(path, '/') + 1);
+
 	// if we have a zip file
 	if (suffixMatch(".zip", game.path)) {
 		LOG_info("is zip file\n");
@@ -208,8 +213,8 @@ static void Game_open(char* path) {
 		char* ext;
 		char exts[128];
 		char* extensions[32];
-		strcpy(exts,core.extensions);
-		while ((ext=strtok(i?NULL:exts,"|"))) {
+		strcpy(exts, core.extensions);
+		while ((ext = strtok(i ? NULL : exts, "|"))) {
 			extensions[i++] = ext;
 			if (!strcmp("zip", ext)) {
 				supports_zip = 1;
@@ -217,15 +222,16 @@ static void Game_open(char* path) {
 			}
 		}
 		extensions[i] = NULL;
-	
+
 		// if the core doesn't support zip files natively
 		if (!supports_zip) {
-			FILE *zip = fopen(game.path, "r");
-			if (zip==NULL) {
-				LOG_error("Error opening archive: %s\n\t%s\n", game.path, strerror(errno));
+			FILE* zip = fopen(game.path, "r");
+			if (zip == NULL) {
+				LOG_error("Error opening archive: %s\n\t%s\n", game.path,
+						  strerror(errno));
 				return;
 			}
-			
+
 			// extract a known file format
 			uint8_t header[ZIP_HEADER_SIZE];
 			uint32_t next = 0;
@@ -235,96 +241,104 @@ static void Game_open(char* path) {
 			char extension[8];
 			while (1) {
 				if (next) fseek(zip, next, SEEK_CUR);
-				
-				if (ZIP_HEADER_SIZE!=fread(header, 1, ZIP_HEADER_SIZE, zip)) break;
-				
+
+				if (ZIP_HEADER_SIZE != fread(header, 1, ZIP_HEADER_SIZE, zip))
+					break;
+
 				if ((uint16_t)(header[6]) & 0x0008) break;
-				
+
 				len = ZIP_LE_READ16(&header[26]);
-				if (len>=MAX_PATH) break;
-				
-				if (len!=fread(filename,1,len,zip)) break;
+				if (len >= MAX_PATH) break;
+
+				if (len != fread(filename, 1, len, zip)) break;
 				filename[len] = '\0';
 				LOG_info("filename: %s\n", filename);
-				
+
 				compressed_size = ZIP_LE_READ32(&header[18]);
-				
+
 				fseek(zip, ZIP_LE_READ16(&header[28]), SEEK_CUR);
 				next = compressed_size;
-				
+
 				int found = 0;
-				for (i=0; extensions[i]; i++) {
+				for (i = 0; extensions[i]; i++) {
 					sprintf(extension, ".%s", extensions[i]);
 					if (suffixMatch(extension, filename)) {
-						
 						found = 1;
 						break;
 					}
 				}
 				if (!found) continue;
-				
+
 				char tmp_template[MAX_PATH];
 				strcpy(tmp_template, "/tmp/minarch-XXXXXX");
 				char* tmp_dirname = mkdtemp(tmp_template);
 				// LOG_info("tmp_dirname: %s\n", tmp_dirname);
-				sprintf(game.tmp_path, "%s/%s", tmp_dirname, basename(filename));
-				
-				// TODO: we need to clear game.tmp_path if anything below this point fails!
-				
+				sprintf(game.tmp_path, "%s/%s", tmp_dirname,
+						basename(filename));
+
+				// TODO: we need to clear game.tmp_path if anything below this
+				// point fails!
+
 				FILE* dst = fopen(game.tmp_path, "w");
-				if (dst==NULL) {
+				if (dst == NULL) {
 					game.tmp_path[0] = '\0';
-					LOG_error("Error extracting file: %s\n\t%s\n", filename, strerror(errno));
+					LOG_error("Error extracting file: %s\n\t%s\n", filename,
+							  strerror(errno));
 					return;
 				}
-				
+
 				Zip_extract_t extract = NULL;
 				switch (ZIP_LE_READ16(&header[8])) {
-					case 0: extract = Zip_copy; break;
-					case 8: extract = Zip_inflate; break;
+					case 0:
+						extract = Zip_copy;
+						break;
+					case 8:
+						extract = Zip_inflate;
+						break;
 				}
-				
-				if (!extract || extract(zip,dst,compressed_size)) {
+
+				if (!extract || extract(zip, dst, compressed_size)) {
 					game.tmp_path[0] = '\0';
-					LOG_error("Error extracting file: %s\n\t%s\n", filename, strerror(errno));
+					LOG_error("Error extracting file: %s\n\t%s\n", filename,
+							  strerror(errno));
 					return;
 				}
-				
+
 				fclose(dst);
-				
+
 				break;
 			}
-			
+
 			fclose(zip);
 		}
 	}
-		
+
 	// some cores handle opening files themselves, eg. pcsx_rearmed
 	// if the frontend tries to load a 500MB file itself bad things happen
 	if (!core.need_fullpath) {
-		path = game.tmp_path[0]=='\0'?game.path:game.tmp_path;
-		
-		FILE *file = fopen(path, "r");
-		if (file==NULL) {
+		path = game.tmp_path[0] == '\0' ? game.path : game.tmp_path;
+
+		FILE* file = fopen(path, "r");
+		if (file == NULL) {
 			LOG_error("Error opening game: %s\n\t%s\n", path, strerror(errno));
 			return;
 		}
-	
+
 		fseek(file, 0, SEEK_END);
 		game.size = ftell(file);
-	
+
 		rewind(file);
 		game.data = malloc(game.size);
-		if (game.data==NULL) {
+		if (game.data == NULL) {
 			LOG_error("Couldn't allocate memory for file: %s\n", path);
 			return;
 		}
-	
+
 		fread(game.data, sizeof(uint8_t), game.size, file);
-	
+
 		fclose(file);
 	}
-	
+
 	// m3u-based?
 	char* tmp;
 	char m3u_path[256];
@@ -334,50 +348,50 @@ static void Game_open(char* path) {
 	strcpy(m3u_path, game.path);
 	tmp = strrchr(m3u_path, '/') + 1;
 	tmp[0] = '\0';
-	
+
 	strcpy(base_path, m3u_path);
-	
+
 	tmp = strrchr(m3u_path, '/');
 	tmp[0] = '\0';
 
 	tmp = strrchr(m3u_path, '/');
 	strcpy(dir_name, tmp);
-	
-	tmp = m3u_path + strlen(m3u_path); 
+
+	tmp = m3u_path + strlen(m3u_path);
 	strcpy(tmp, dir_name);
-	
+
 	tmp = m3u_path + strlen(m3u_path);
 	strcpy(tmp, ".m3u");
-	
+
 	if (exists(m3u_path)) {
 		strcpy(game.m3u_path, m3u_path);
-		strcpy((char*)game.name, strrchr(m3u_path, '/')+1);
+		strcpy((char*)game.name, strrchr(m3u_path, '/') + 1);
 	}
-	
+
 	game.is_open = 1;
 }
 static void Game_close(void) {
 	if (game.data) free(game.data);
 	if (game.tmp_path[0]) remove(game.tmp_path);
 	game.is_open = 0;
-	VIB_setStrength(0); // just in case
+	VIB_setStrength(0);	 // just in case
 }
 
 static struct retro_disk_control_ext_callback disk_control_ext;
 static void Game_changeDisc(char* path) {
-	
 	if (exactMatch(game.path, path) || !exists(path)) return;
-	
+
 	Game_close();
 	Game_open(path);
-	
+
 	struct retro_game_info game_info = {};
 	game_info.path = game.path;
 	game_info.data = game.data;
 	game_info.size = game.size;
-	
+
 	disk_control_ext.replace_image_index(0, &game_info);
-	putFile(CHANGE_DISC_PATH, path); // MinUI still needs to know this to update recents.txt
+	putFile(CHANGE_DISC_PATH,
+			path);	// MinUI still needs to know this to update recents.txt
 }
 
 ///////////////////////////////////////
@@ -388,12 +402,12 @@ static void SRAM_getPath(char* filename) {
 static void SRAM_read(void) {
 	size_t sram_size = core.get_memory_size(RETRO_MEMORY_SAVE_RAM);
 	if (!sram_size) return;
-	
+
 	char filename[MAX_PATH];
 	SRAM_getPath(filename);
 	printf("sav path (read): %s\n", filename);
-	
-	FILE *sram_file = fopen(filename, "r");
+
+	FILE* sram_file = fopen(filename, "r");
 	if (!sram_file) return;
 
 	void* sram = core.get_memory_data(RETRO_MEMORY_SAVE_RAM);
@@ -407,18 +421,18 @@ static void SRAM_read(void) {
 static void SRAM_write(void) {
 	size_t sram_size = core.get_memory_size(RETRO_MEMORY_SAVE_RAM);
 	if (!sram_size) return;
-	
+
 	char filename[MAX_PATH];
 	SRAM_getPath(filename);
 	printf("sav path (write): %s\n", filename);
-		
-	FILE *sram_file = fopen(filename, "w");
+
+	FILE* sram_file = fopen(filename, "w");
 	if (!sram_file) {
 		LOG_error("Error opening SRAM file: %s\n", strerror(errno));
 		return;
 	}
 
-	void *sram = core.get_memory_data(RETRO_MEMORY_SAVE_RAM);
+	void* sram = core.get_memory_data(RETRO_MEMORY_SAVE_RAM);
 
 	if (!sram || sram_size != fwrite(sram, 1, sram_size, sram_file)) {
 		LOG_error("Error writing SRAM data to file\n");
@@ -437,12 +451,12 @@ static void RTC_getPath(char* filename) {
 static void RTC_read(void) {
 	size_t rtc_size = core.get_memory_size(RETRO_MEMORY_RTC);
 	if (!rtc_size) return;
-	
+
 	char filename[MAX_PATH];
 	RTC_getPath(filename);
 	printf("rtc path (read): %s\n", filename);
-	
-	FILE *rtc_file = fopen(filename, "r");
+
+	FILE* rtc_file = fopen(filename, "r");
 	if (!rtc_file) return;
 
 	void* rtc = core.get_memory_data(RETRO_MEMORY_RTC);
@@ -456,18 +470,18 @@ static void RTC_read(void) {
 static void RTC_write(void) {
 	size_t rtc_size = core.get_memory_size(RETRO_MEMORY_RTC);
 	if (!rtc_size) return;
-	
+
 	char filename[MAX_PATH];
 	RTC_getPath(filename);
 	printf("rtc path (write) size(%u): %s\n", rtc_size, filename);
-		
-	FILE *rtc_file = fopen(filename, "w");
+
+	FILE* rtc_file = fopen(filename, "w");
 	if (!rtc_file) {
 		LOG_error("Error opening RTC file: %s\n", strerror(errno));
 		return;
 	}
 
-	void *rtc = core.get_memory_data(RETRO_MEMORY_RTC);
+	void* rtc = core.get_memory_data(RETRO_MEMORY_RTC);
 
 	if (!rtc || rtc_size != fwrite(rtc, 1, rtc_size, rtc_file)) {
 		LOG_error("Error writing RTC data to file\n");
@@ -484,14 +498,14 @@ static int state_slot = 0;
 static void State_getPath(char* filename) {
 	sprintf(filename, "%s/%s.st%i", core.states_dir, game.name, state_slot);
 }
-static void State_read(void) { // from picoarch
+static void State_read(void) {	// from picoarch
 	size_t state_size = core.serialize_size();
 	if (!state_size) return;
 
 	int was_ff = fast_forward;
 	fast_forward = 0;
 
-	void *state = calloc(1, state_size);
+	void* state = calloc(1, state_size);
 	if (!state) {
 		LOG_error("Couldn't allocate memory for state\n");
 		goto error;
@@ -499,41 +513,46 @@ static void State_read(void) { // from picoarch
 
 	char filename[MAX_PATH];
 	State_getPath(filename);
-	
-	FILE *state_file = fopen(filename, "r");
+
+	FILE* state_file = fopen(filename, "r");
 	if (!state_file) {
-		if (state_slot!=8) { // st8 is a default state in MiniUI and may not exist, that's okay
-			LOG_error("Error opening state file: %s (%s)\n", filename, strerror(errno));
+		if (state_slot != 8) {	// st8 is a default state in MiniUI and may not
+								// exist, that's okay
+			LOG_error("Error opening state file: %s (%s)\n", filename,
+					  strerror(errno));
 		}
 		goto error;
 	}
-	
-	// some cores report the wrong serialize size initially for some games, eg. mgba: Wario Land 4
-	// so we allow a size mismatch as long as the actual size fits in the buffer we've allocated
+
+	// some cores report the wrong serialize size initially for some games, eg.
+	// mgba: Wario Land 4 so we allow a size mismatch as long as the actual size
+	// fits in the buffer we've allocated
 	if (state_size < fread(state, 1, state_size, state_file)) {
-		LOG_error("Error reading state data from file: %s (%s)\n", filename, strerror(errno));
+		LOG_error("Error reading state data from file: %s (%s)\n", filename,
+				  strerror(errno));
 		goto error;
 	}
 
 	if (!core.unserialize(state, state_size)) {
-		LOG_error("Error restoring save state: %s (%s)\n", filename, strerror(errno));
+		LOG_error("Error restoring save state: %s (%s)\n", filename,
+				  strerror(errno));
 		goto error;
 	}
 
 error:
 	if (state) free(state);
 	if (state_file) fclose(state_file);
-	
+
 	fast_forward = was_ff;
 }
-static void State_write(void) { // from picoarch
+static void State_write(void) {	 // from picoarch
 	size_t state_size = core.serialize_size();
 	if (!state_size) return;
-	
+
 	int was_ff = fast_forward;
 	fast_forward = 0;
 
-	void *state = calloc(1, state_size);
+	void* state = calloc(1, state_size);
 	if (!state) {
 		LOG_error("Couldn't allocate memory for state\n");
 		goto error;
@@ -541,20 +560,23 @@ static void State_write(void) { // from picoarch
 
 	char filename[MAX_PATH];
 	State_getPath(filename);
-	
-	FILE *state_file = fopen(filename, "w");
+
+	FILE* state_file = fopen(filename, "w");
 	if (!state_file) {
-		LOG_error("Error opening state file: %s (%s)\n", filename, strerror(errno));
+		LOG_error("Error opening state file: %s (%s)\n", filename,
+				  strerror(errno));
 		goto error;
 	}
 
 	if (!core.serialize(state, state_size)) {
-		LOG_error("Error creating save state: %s (%s)\n", filename, strerror(errno));
+		LOG_error("Error creating save state: %s (%s)\n", filename,
+				  strerror(errno));
 		goto error;
 	}
 
 	if (state_size != fwrite(state, 1, state_size, state_file)) {
-		LOG_error("Error writing state data to file: %s (%s)\n", filename, strerror(errno));
+		LOG_error("Error writing state data to file: %s (%s)\n", filename,
+				  strerror(errno));
 		goto error;
 	}
 
@@ -563,7 +585,7 @@ error:
 	if (state_file) fclose(state_file);
 
 	sync();
-	
+
 	fast_forward = was_ff;
 }
 static void State_autosave(void) {
@@ -574,7 +596,7 @@ static void State_autosave(void) {
 }
 static void State_resume(void) {
 	if (!exists(RESUME_SLOT_PATH)) return;
-	
+
 	int last_state_slot = state_slot;
 	state_slot = getInt(RESUME_SLOT_PATH);
 	unlink(RESUME_SLOT_PATH);
@@ -586,13 +608,13 @@ static void State_resume(void) {
 
 typedef struct Option {
 	char* key;
-	char* name; // desc
-	char* desc; // info, truncated
-	char* full; // info, longer but possibly still truncated
+	char* name;	 // desc
+	char* desc;	 // info, truncated
+	char* full;	 // info, longer but possibly still truncated
 	char* var;
 	int default_value;
 	int value;
-	int count; // TODO: drop this?
+	int count;	// TODO: drop this?
 	int lock;
 	char** values;
 	char** labels;
@@ -601,52 +623,20 @@ typedef struct OptionList {
 	int count;
 	int changed;
 	Option* options;
-	
+
 	int enabled_count;
 	Option** enabled_options;
 	// OptionList_callback_t on_set;
 } OptionList;
 
-static char* onoff_labels[] = {
-	"Off",
-	"On",
-	NULL
-};
-static char* scaling_labels[] = {
-	"Native",
-	"Aspect",
-	"Fullscreen",
-	"Cropped",
-	NULL
-};
-static char* effect_labels[] = {
-	"None",
-	"Line",
-	"Grid",
-	NULL
-};
-static char* sharpness_labels[] = {
-	"Sharp",
-	"Crisp",
-	"Soft",
-	NULL
-};
-static char* tearing_labels[] = {
-	"Off",
-	"Lenient",
-	"Strict",
-	NULL
-};
+static char* onoff_labels[] = {"Off", "On", NULL};
+static char* scaling_labels[] = {"Native", "Aspect", "Fullscreen", "Cropped",
+								 NULL};
+static char* effect_labels[] = {"None", "Line", "Grid", NULL};
+static char* sharpness_labels[] = {"Sharp", "Crisp", "Soft", NULL};
+static char* tearing_labels[] = {"Off", "Lenient", "Strict", NULL};
 static char* max_ff_labels[] = {
-	"None",
-	"2x",
-	"3x",
-	"4x",
-	"5x",
-	"6x",
-	"7x",
-	"8x",
-	NULL,
+	"None", "2x", "3x", "4x", "5x", "6x", "7x", "8x", NULL,
 };
 
 ///////////////////////////////
@@ -675,115 +665,90 @@ enum {
 	SHORTCUT_COUNT,
 };
 
-#define LOCAL_BUTTON_COUNT 16 // depends on device
-#define RETRO_BUTTON_COUNT 16 // allow L3/R3 to be remapped by user if desired, eg. Virtual Boy uses extra buttons for right d-pad
+#define LOCAL_BUTTON_COUNT 16  // depends on device
+#define RETRO_BUTTON_COUNT \
+	16	// allow L3/R3 to be remapped by user if desired, eg. Virtual Boy uses
+		// extra buttons for right d-pad
 
-typedef struct ButtonMapping { 
+typedef struct ButtonMapping {
 	char* name;
 	int retro;
-	int local; // TODO: dislike this name...
+	int local;	// TODO: dislike this name...
 	int mod;
 	int default_;
 	int ignore;
 } ButtonMapping;
 
-static ButtonMapping default_button_mapping[] = { // used if pak.cfg doesn't exist or doesn't have bindings
-	{"Up",			RETRO_DEVICE_ID_JOYPAD_UP,		BTN_ID_DPAD_UP},
-	{"Down",		RETRO_DEVICE_ID_JOYPAD_DOWN,	BTN_ID_DPAD_DOWN},
-	{"Left",		RETRO_DEVICE_ID_JOYPAD_LEFT,	BTN_ID_DPAD_LEFT},
-	{"Right",		RETRO_DEVICE_ID_JOYPAD_RIGHT,	BTN_ID_DPAD_RIGHT},
-	{"A Button",	RETRO_DEVICE_ID_JOYPAD_A,		BTN_ID_A},
-	{"B Button",	RETRO_DEVICE_ID_JOYPAD_B,		BTN_ID_B},
-	{"X Button",	RETRO_DEVICE_ID_JOYPAD_X,		BTN_ID_X},
-	{"Y Button",	RETRO_DEVICE_ID_JOYPAD_Y,		BTN_ID_Y},
-	{"Start",		RETRO_DEVICE_ID_JOYPAD_START,	BTN_ID_START},
-	{"Select",		RETRO_DEVICE_ID_JOYPAD_SELECT,	BTN_ID_SELECT},
-	{"L1 Button",	RETRO_DEVICE_ID_JOYPAD_L,		BTN_ID_L1},
-	{"R1 Button",	RETRO_DEVICE_ID_JOYPAD_R,		BTN_ID_R1},
-	{"L2 Button",	RETRO_DEVICE_ID_JOYPAD_L2,		BTN_ID_L2},
-	{"R2 Button",	RETRO_DEVICE_ID_JOYPAD_R2,		BTN_ID_R2},
-	{"L3 Button",	RETRO_DEVICE_ID_JOYPAD_L3,		BTN_ID_L3},
-	{"R3 Button",	RETRO_DEVICE_ID_JOYPAD_R3,		BTN_ID_R3},
-	{NULL,0,0}
-};
-static ButtonMapping button_label_mapping[] = { // used to lookup the retro_id and local btn_id from button name
-	{"NONE",	-1,								BTN_ID_NONE},
-	{"UP",		RETRO_DEVICE_ID_JOYPAD_UP,		BTN_ID_DPAD_UP},
-	{"DOWN",	RETRO_DEVICE_ID_JOYPAD_DOWN,	BTN_ID_DPAD_DOWN},
-	{"LEFT",	RETRO_DEVICE_ID_JOYPAD_LEFT,	BTN_ID_DPAD_LEFT},
-	{"RIGHT",	RETRO_DEVICE_ID_JOYPAD_RIGHT,	BTN_ID_DPAD_RIGHT},
-	{"A",		RETRO_DEVICE_ID_JOYPAD_A,		BTN_ID_A},
-	{"B",		RETRO_DEVICE_ID_JOYPAD_B,		BTN_ID_B},
-	{"X",		RETRO_DEVICE_ID_JOYPAD_X,		BTN_ID_X},
-	{"Y",		RETRO_DEVICE_ID_JOYPAD_Y,		BTN_ID_Y},
-	{"START",	RETRO_DEVICE_ID_JOYPAD_START,	BTN_ID_START},
-	{"SELECT",	RETRO_DEVICE_ID_JOYPAD_SELECT,	BTN_ID_SELECT},
-	{"L1",		RETRO_DEVICE_ID_JOYPAD_L,		BTN_ID_L1},
-	{"R1",		RETRO_DEVICE_ID_JOYPAD_R,		BTN_ID_R1},
-	{"L2",		RETRO_DEVICE_ID_JOYPAD_L2,		BTN_ID_L2},
-	{"R2",		RETRO_DEVICE_ID_JOYPAD_R2,		BTN_ID_R2},
-	{"L3",		RETRO_DEVICE_ID_JOYPAD_L3,		BTN_ID_L3},
-	{"R3",		RETRO_DEVICE_ID_JOYPAD_R3,		BTN_ID_R3},
-	{NULL,0,0}
-};
-static ButtonMapping core_button_mapping[RETRO_BUTTON_COUNT+1] = {0};
+static ButtonMapping default_button_mapping[] =
+	{  // used if pak.cfg doesn't exist or doesn't have bindings
+		{"Up", RETRO_DEVICE_ID_JOYPAD_UP, BTN_ID_DPAD_UP},
+		{"Down", RETRO_DEVICE_ID_JOYPAD_DOWN, BTN_ID_DPAD_DOWN},
+		{"Left", RETRO_DEVICE_ID_JOYPAD_LEFT, BTN_ID_DPAD_LEFT},
+		{"Right", RETRO_DEVICE_ID_JOYPAD_RIGHT, BTN_ID_DPAD_RIGHT},
+		{"A Button", RETRO_DEVICE_ID_JOYPAD_A, BTN_ID_A},
+		{"B Button", RETRO_DEVICE_ID_JOYPAD_B, BTN_ID_B},
+		{"X Button", RETRO_DEVICE_ID_JOYPAD_X, BTN_ID_X},
+		{"Y Button", RETRO_DEVICE_ID_JOYPAD_Y, BTN_ID_Y},
+		{"Start", RETRO_DEVICE_ID_JOYPAD_START, BTN_ID_START},
+		{"Select", RETRO_DEVICE_ID_JOYPAD_SELECT, BTN_ID_SELECT},
+		{"L1 Button", RETRO_DEVICE_ID_JOYPAD_L, BTN_ID_L1},
+		{"R1 Button", RETRO_DEVICE_ID_JOYPAD_R, BTN_ID_R1},
+		{"L2 Button", RETRO_DEVICE_ID_JOYPAD_L2, BTN_ID_L2},
+		{"R2 Button", RETRO_DEVICE_ID_JOYPAD_R2, BTN_ID_R2},
+		{"L3 Button", RETRO_DEVICE_ID_JOYPAD_L3, BTN_ID_L3},
+		{"R3 Button", RETRO_DEVICE_ID_JOYPAD_R3, BTN_ID_R3},
+		{NULL, 0, 0}};
+static ButtonMapping button_label_mapping[] =
+	{  // used to lookup the retro_id and local btn_id from button name
+		{"NONE", -1, BTN_ID_NONE},
+		{"UP", RETRO_DEVICE_ID_JOYPAD_UP, BTN_ID_DPAD_UP},
+		{"DOWN", RETRO_DEVICE_ID_JOYPAD_DOWN, BTN_ID_DPAD_DOWN},
+		{"LEFT", RETRO_DEVICE_ID_JOYPAD_LEFT, BTN_ID_DPAD_LEFT},
+		{"RIGHT", RETRO_DEVICE_ID_JOYPAD_RIGHT, BTN_ID_DPAD_RIGHT},
+		{"A", RETRO_DEVICE_ID_JOYPAD_A, BTN_ID_A},
+		{"B", RETRO_DEVICE_ID_JOYPAD_B, BTN_ID_B},
+		{"X", RETRO_DEVICE_ID_JOYPAD_X, BTN_ID_X},
+		{"Y", RETRO_DEVICE_ID_JOYPAD_Y, BTN_ID_Y},
+		{"START", RETRO_DEVICE_ID_JOYPAD_START, BTN_ID_START},
+		{"SELECT", RETRO_DEVICE_ID_JOYPAD_SELECT, BTN_ID_SELECT},
+		{"L1", RETRO_DEVICE_ID_JOYPAD_L, BTN_ID_L1},
+		{"R1", RETRO_DEVICE_ID_JOYPAD_R, BTN_ID_R1},
+		{"L2", RETRO_DEVICE_ID_JOYPAD_L2, BTN_ID_L2},
+		{"R2", RETRO_DEVICE_ID_JOYPAD_R2, BTN_ID_R2},
+		{"L3", RETRO_DEVICE_ID_JOYPAD_L3, BTN_ID_L3},
+		{"R3", RETRO_DEVICE_ID_JOYPAD_R3, BTN_ID_R3},
+		{NULL, 0, 0}};
+static ButtonMapping core_button_mapping[RETRO_BUTTON_COUNT + 1] = {0};
 
 static const char* device_button_names[LOCAL_BUTTON_COUNT] = {
-	[BTN_ID_DPAD_UP]	= "UP",
-	[BTN_ID_DPAD_DOWN]	= "DOWN",
-	[BTN_ID_DPAD_LEFT]	= "LEFT",
-	[BTN_ID_DPAD_RIGHT]	= "RIGHT",
-	[BTN_ID_SELECT]		= "SELECT",
-	[BTN_ID_START]		= "START",
-	[BTN_ID_Y]			= "Y",
-	[BTN_ID_X]			= "X",
-	[BTN_ID_B]			= "B",
-	[BTN_ID_A]			= "A",
-	[BTN_ID_L1]			= "L1",
-	[BTN_ID_R1]			= "R1",
-	[BTN_ID_L2]			= "L2",
-	[BTN_ID_R2]			= "R2",
-	[BTN_ID_L3]			= "L3",
-	[BTN_ID_R3]			= "R3",
+	[BTN_ID_DPAD_UP] = "UP",
+	[BTN_ID_DPAD_DOWN] = "DOWN",
+	[BTN_ID_DPAD_LEFT] = "LEFT",
+	[BTN_ID_DPAD_RIGHT] = "RIGHT",
+	[BTN_ID_SELECT] = "SELECT",
+	[BTN_ID_START] = "START",
+	[BTN_ID_Y] = "Y",
+	[BTN_ID_X] = "X",
+	[BTN_ID_B] = "B",
+	[BTN_ID_A] = "A",
+	[BTN_ID_L1] = "L1",
+	[BTN_ID_R1] = "R1",
+	[BTN_ID_L2] = "L2",
+	[BTN_ID_R2] = "R2",
+	[BTN_ID_L3] = "L3",
+	[BTN_ID_R3] = "R3",
 };
 
-
-// NOTE: these must be in BTN_ID_ order also off by 1 because of NONE (which is -1 in BTN_ID_ land)
+// NOTE: these must be in BTN_ID_ order also off by 1 because of NONE (which is
+// -1 in BTN_ID_ land)
 static char* button_labels[] = {
-	"NONE", // displayed by default
-	"UP",
-	"DOWN",
-	"LEFT",
-	"RIGHT",
-	"A",
-	"B",
-	"X",
-	"Y",
-	"START",
-	"SELECT",
-	"L1",
-	"R1",
-	"L2",
-	"R2",
-	"L3",
-	"R3",
-	"MENU+UP",
-	"MENU+DOWN",
-	"MENU+LEFT",
-	"MENU+RIGHT",
-	"MENU+A",
-	"MENU+B",
-	"MENU+X",
-	"MENU+Y",
-	"MENU+START",
-	"MENU+SELECT",
-	"MENU+L1",
-	"MENU+R1",
-	"MENU+L2",
-	"MENU+R2",
-	"MENU+L3",
-	"MENU+R3",
-	NULL,
+	"NONE",	 // displayed by default
+	"UP",		  "DOWN",		 "LEFT",	"RIGHT",   "A",		  "B",
+	"X",		  "Y",			 "START",	"SELECT",  "L1",	  "R1",
+	"L2",		  "R2",			 "L3",		"R3",	   "MENU+UP", "MENU+DOWN",
+	"MENU+LEFT",  "MENU+RIGHT",	 "MENU+A",	"MENU+B",  "MENU+X",  "MENU+Y",
+	"MENU+START", "MENU+SELECT", "MENU+L1", "MENU+R1", "MENU+L2", "MENU+R2",
+	"MENU+L3",	  "MENU+R3",	 NULL,
 };
 static char* overclock_labels[] = {
 	"Powersave",
@@ -812,21 +777,22 @@ enum {
 
 static inline char* getScreenScalingDesc(void) {
 	if (GFX_supportsOverscan()) {
-		return "Native uses integer scaling. Aspect uses core\nreported aspect ratio. Fullscreen has non-square\npixels. Cropped is integer scaled then cropped.";
-	}
-	else {
-		return "Native uses integer scaling.\nAspect uses core reported aspect ratio.\nFullscreen has non-square pixels.";
+		return "Native uses integer scaling. Aspect uses core\nreported aspect "
+			   "ratio. Fullscreen has non-square\npixels. Cropped is integer "
+			   "scaled then cropped.";
+	} else {
+		return "Native uses integer scaling.\nAspect uses core reported aspect "
+			   "ratio.\nFullscreen has non-square pixels.";
 	}
 }
 static inline int getScreenScalingCount(void) {
 	return GFX_supportsOverscan() ? 4 : 3;
 }
-	
 
 static struct Config {
-	char* system_cfg; // system.cfg based on system limitations
-	char* default_cfg; // pak.cfg based on platform limitations
-	char* user_cfg; // minarch.cfg or game.cfg based on user preference
+	char* system_cfg;	// system.cfg based on system limitations
+	char* default_cfg;	// pak.cfg based on platform limitations
+	char* user_cfg;		// minarch.cfg or game.cfg based on user preference
 	char* device_tag;
 	OptionList frontend;
 	OptionList core;
@@ -835,272 +801,307 @@ static struct Config {
 	int loaded;
 	int initialized;
 } config = {
-	.frontend = { // (OptionList)
-		.count = FE_OPT_COUNT,
-		.options = (Option[]){
-			[FE_OPT_SCALING] = {
-				.key	= "minarch_screen_scaling", 
-				.name	= "Screen Scaling",
-				.desc	= NULL, // will call getScreenScalingDesc()
-				.default_value = 1,
-				.value = 1,
-				.count = 3, // will call getScreenScalingCount()
-				.values = scaling_labels,
-				.labels = scaling_labels,
-			},
-			[FE_OPT_EFFECT] = {
-				.key	= "minarch_screen_effect",
-				.name	= "Screen Effect",
-				.desc	= "Grid simulates an LCD grid.\nLine simulates CRT scanlines.\nEffects usually look best at native scaling.",
-				.default_value = 0,
-				.value = 0,
-				.count = 3,
-				.values = effect_labels,
-				.labels = effect_labels,
-			},
-			[FE_OPT_SHARPNESS] = {
-				.key	= "minarch_screen_sharpness",
-				.name	= "Screen Sharpness",
-				.desc	= "Sharp uses nearest neighbor sampling.\nCrisp integer upscales before linear sampling.\nSoft uses linear sampling.",
-				.default_value = 2,
-				.value = 2,
-				.count = 3,
-				.values = sharpness_labels,
-				.labels = sharpness_labels,
-			},
-			[FE_OPT_TEARING] = {
-				.key	= "minarch_prevent_tearing",
-				.name	= "Prevent Tearing",
-				.desc	= "Wait for vsync before drawing the next frame.\nLenient only waits when within frame budget.\nStrict always waits.",
-				.default_value = VSYNC_LENIENT,
-				.value = VSYNC_LENIENT,
-				.count = 3,
-				.values = tearing_labels,
-				.labels = tearing_labels,
-			},
-			[FE_OPT_OVERCLOCK] = {
-				.key	= "minarch_cpu_speed",
-				.name	= "CPU Speed",
-				.desc	= "Over- or underclock the CPU to prioritize\npure performance or power savings.",
-				.default_value = 1,
-				.value = 1,
-				.count = 3,
-				.values = overclock_labels,
-				.labels = overclock_labels,
-			},
-			[FE_OPT_THREAD] = {
-				.key	= "minarch_thread_video",
-				.name	= "Prioritize Audio",
-				.desc	= "Can eliminate crackle but\nmay cause dropped frames.\nOnly turn on if necessary.",
-				.default_value = 0,
-				.value = 0,
-				.count = 2,
-				.values = onoff_labels,
-				.labels = onoff_labels,
-			},
-			[FE_OPT_DEBUG] = {
-				.key	= "minarch_debug_hud",
-				.name	= "Debug HUD",
-				.desc	= "Show frames per second, cpu load,\nresolution, and scaler information.",
-				.default_value = 0,
-				.value = 0,
-				.count = 2,
-				.values = onoff_labels,
-				.labels = onoff_labels,
-			},
-			[FE_OPT_MAXFF] = {
-				.key	= "minarch_max_ff_speed",
-				.name	= "Max FF Speed",
-				.desc	= "Fast forward will not exceed the\nselected speed (but may be less\ndepending on game and emulator).",
-				.default_value = 3, // 4x
-				.value = 3, // 4x
-				.count = 8,
-				.values = max_ff_labels,
-				.labels = max_ff_labels,
-			},
-			[FE_OPT_COUNT] = {NULL}
-		}
-	},
-	.core = { // (OptionList)
-		.count = 0,
-		.options = (Option[]){
-			{NULL},
+	.frontend =
+		{// (OptionList)
+		 .count = FE_OPT_COUNT,
+		 .options =
+			 (Option[]){
+				 [FE_OPT_SCALING] =
+					 {
+						 .key = "minarch_screen_scaling",
+						 .name = "Screen Scaling",
+						 .desc = NULL,	// will call getScreenScalingDesc()
+						 .default_value = 1,
+						 .value = 1,
+						 .count = 3,  // will call getScreenScalingCount()
+						 .values = scaling_labels,
+						 .labels = scaling_labels,
+					 },
+				 [FE_OPT_EFFECT] =
+					 {
+						 .key = "minarch_screen_effect",
+						 .name = "Screen Effect",
+						 .desc = "Grid simulates an LCD grid.\nLine simulates "
+								 "CRT scanlines.\nEffects usually look best at "
+								 "native scaling.",
+						 .default_value = 0,
+						 .value = 0,
+						 .count = 3,
+						 .values = effect_labels,
+						 .labels = effect_labels,
+					 },
+				 [FE_OPT_SHARPNESS] =
+					 {
+						 .key = "minarch_screen_sharpness",
+						 .name = "Screen Sharpness",
+						 .desc = "Sharp uses nearest neighbor sampling.\nCrisp "
+								 "integer upscales before linear "
+								 "sampling.\nSoft uses linear sampling.",
+						 .default_value = 2,
+						 .value = 2,
+						 .count = 3,
+						 .values = sharpness_labels,
+						 .labels = sharpness_labels,
+					 },
+				 [FE_OPT_TEARING] =
+					 {
+						 .key = "minarch_prevent_tearing",
+						 .name = "Prevent Tearing",
+						 .desc = "Wait for vsync before drawing the next "
+								 "frame.\nLenient only waits when within frame "
+								 "budget.\nStrict always waits.",
+						 .default_value = VSYNC_LENIENT,
+						 .value = VSYNC_LENIENT,
+						 .count = 3,
+						 .values = tearing_labels,
+						 .labels = tearing_labels,
+					 },
+				 [FE_OPT_OVERCLOCK] =
+					 {
+						 .key = "minarch_cpu_speed",
+						 .name = "CPU Speed",
+						 .desc =
+							 "Over- or underclock the CPU to prioritize\npure "
+							 "performance or power savings.",
+						 .default_value = 1,
+						 .value = 1,
+						 .count = 3,
+						 .values = overclock_labels,
+						 .labels = overclock_labels,
+					 },
+				 [FE_OPT_THREAD] =
+					 {
+						 .key = "minarch_thread_video",
+						 .name = "Prioritize Audio",
+						 .desc = "Can eliminate crackle but\nmay cause dropped "
+								 "frames.\nOnly turn on if necessary.",
+						 .default_value = 0,
+						 .value = 0,
+						 .count = 2,
+						 .values = onoff_labels,
+						 .labels = onoff_labels,
+					 },
+				 [FE_OPT_DEBUG] =
+					 {
+						 .key = "minarch_debug_hud",
+						 .name = "Debug HUD",
+						 .desc = "Show frames per second, cpu "
+								 "load,\nresolution, and scaler information.",
+						 .default_value = 0,
+						 .value = 0,
+						 .count = 2,
+						 .values = onoff_labels,
+						 .labels = onoff_labels,
+					 },
+				 [FE_OPT_MAXFF] =
+					 {
+						 .key = "minarch_max_ff_speed",
+						 .name = "Max FF Speed",
+						 .desc = "Fast forward will not exceed the\nselected "
+								 "speed (but may be less\ndepending on game "
+								 "and emulator).",
+						 .default_value = 3,  // 4x
+						 .value = 3,		  // 4x
+						 .count = 8,
+						 .values = max_ff_labels,
+						 .labels = max_ff_labels,
+					 },
+				 [FE_OPT_COUNT] = {NULL}}},
+	.core =
+		{
+			// (OptionList)
+			.count = 0,
+			.options =
+				(Option[]){
+					{NULL},
+				},
 		},
-	},
 	.controls = default_button_mapping,
-	.shortcuts = (ButtonMapping[]){
-		[SHORTCUT_SAVE_STATE]			= {"Save State",		-1, BTN_ID_NONE, 0},
-		[SHORTCUT_LOAD_STATE]			= {"Load State",		-1, BTN_ID_NONE, 0},
-		[SHORTCUT_RESET_GAME]			= {"Reset Game",		-1, BTN_ID_NONE, 0},
-		[SHORTCUT_SAVE_QUIT]			= {"Save & Quit",		-1, BTN_ID_NONE, 0},
-		[SHORTCUT_CYCLE_SCALE]			= {"Cycle Scaling",		-1, BTN_ID_NONE, 0},
-		[SHORTCUT_CYCLE_EFFECT]			= {"Cycle Effect",		-1, BTN_ID_NONE, 0},
-		[SHORTCUT_TOGGLE_FF]			= {"Toggle FF",			-1, BTN_ID_NONE, 0},
-		[SHORTCUT_HOLD_FF]				= {"Hold FF",			-1, BTN_ID_NONE, 0},
-		{NULL}
-	},
+	.shortcuts =
+		(ButtonMapping[]){
+			[SHORTCUT_SAVE_STATE] = {"Save State", -1, BTN_ID_NONE, 0},
+			[SHORTCUT_LOAD_STATE] = {"Load State", -1, BTN_ID_NONE, 0},
+			[SHORTCUT_RESET_GAME] = {"Reset Game", -1, BTN_ID_NONE, 0},
+			[SHORTCUT_SAVE_QUIT] = {"Save & Quit", -1, BTN_ID_NONE, 0},
+			[SHORTCUT_CYCLE_SCALE] = {"Cycle Scaling", -1, BTN_ID_NONE, 0},
+			[SHORTCUT_CYCLE_EFFECT] = {"Cycle Effect", -1, BTN_ID_NONE, 0},
+			[SHORTCUT_TOGGLE_FF] = {"Toggle FF", -1, BTN_ID_NONE, 0},
+			[SHORTCUT_HOLD_FF] = {"Hold FF", -1, BTN_ID_NONE, 0},
+			{NULL}},
 };
-static int Config_getValue(char* cfg, const char* key, char* out_value, int* lock) { // gets value from string
+static int Config_getValue(char* cfg, const char* key, char* out_value,
+						   int* lock) {	 // gets value from string
 	char* tmp = cfg;
 	while ((tmp = strstr(tmp, key))) {
-		if (lock!=NULL && tmp>cfg && *(tmp-1)=='-') *lock = 1; // prefixed with a `-` means lock
+		if (lock != NULL && tmp > cfg && *(tmp - 1) == '-')
+			*lock = 1;	// prefixed with a `-` means lock
 		tmp += strlen(key);
-		if (!strncmp(tmp, " = ", 3)) break; // matched
+		if (!strncmp(tmp, " = ", 3)) break;	 // matched
 	};
 	if (!tmp) return 0;
 	tmp += 3;
-	
+
 	strncpy(out_value, tmp, 256);
 	out_value[256 - 1] = '\0';
 	tmp = strchr(out_value, '\n');
 	if (!tmp) tmp = strchr(out_value, '\r');
 	if (tmp) *tmp = '\0';
 
-	// LOG_info("\t%s = %s (%s)\n", key, out_value, (lock && *lock) ? "hidden":"shown");
+	// LOG_info("\t%s = %s (%s)\n", key, out_value, (lock && *lock) ?
+	// "hidden":"shown");
 	return 1;
 }
 
 static void setOverclock(int i) {
 	overclock = i;
 	switch (i) {
-		case 0: PWR_setCPUSpeed(CPU_SPEED_POWERSAVE); break;
-		case 1: PWR_setCPUSpeed(CPU_SPEED_NORMAL); break;
-		case 2: PWR_setCPUSpeed(CPU_SPEED_PERFORMANCE); break;
+		case 0:
+			PWR_setCPUSpeed(CPU_SPEED_POWERSAVE);
+			break;
+		case 1:
+			PWR_setCPUSpeed(CPU_SPEED_NORMAL);
+			break;
+		case 2:
+			PWR_setCPUSpeed(CPU_SPEED_PERFORMANCE);
+			break;
 	}
 }
 static int toggle_thread = 0;
 static void Config_syncFrontend(char* key, int value) {
 	int i = -1;
-	if (exactMatch(key,config.frontend.options[FE_OPT_SCALING].key)) {
-		screen_scaling 	= value;
-		
-		if (screen_scaling==SCALE_NATIVE) GFX_setSharpness(SHARPNESS_SHARP);
-		else GFX_setSharpness(screen_sharpness);
-		
+	if (exactMatch(key, config.frontend.options[FE_OPT_SCALING].key)) {
+		screen_scaling = value;
+
+		if (screen_scaling == SCALE_NATIVE)
+			GFX_setSharpness(SHARPNESS_SHARP);
+		else
+			GFX_setSharpness(screen_sharpness);
+
 		renderer.dst_p = 0;
 		i = FE_OPT_SCALING;
-	}
-	else if (exactMatch(key,config.frontend.options[FE_OPT_EFFECT].key)) {
+	} else if (exactMatch(key, config.frontend.options[FE_OPT_EFFECT].key)) {
 		screen_effect = value;
 		GFX_setEffect(value);
 		renderer.dst_p = 0;
 		i = FE_OPT_EFFECT;
-	}
-	else if (exactMatch(key,config.frontend.options[FE_OPT_SHARPNESS].key)) {
+	} else if (exactMatch(key, config.frontend.options[FE_OPT_SHARPNESS].key)) {
 		screen_sharpness = value;
-		
-		if (screen_scaling==SCALE_NATIVE) GFX_setSharpness(SHARPNESS_SHARP);
-		else GFX_setSharpness(screen_sharpness);
+
+		if (screen_scaling == SCALE_NATIVE)
+			GFX_setSharpness(SHARPNESS_SHARP);
+		else
+			GFX_setSharpness(screen_sharpness);
 
 		renderer.dst_p = 0;
 		i = FE_OPT_SHARPNESS;
-	}
-	else if (exactMatch(key,config.frontend.options[FE_OPT_TEARING].key)) {
+	} else if (exactMatch(key, config.frontend.options[FE_OPT_TEARING].key)) {
 		prevent_tearing = value;
 		i = FE_OPT_TEARING;
-	}
-	else if (exactMatch(key,config.frontend.options[FE_OPT_THREAD].key)) {
+	} else if (exactMatch(key, config.frontend.options[FE_OPT_THREAD].key)) {
 		int old_value = thread_video || was_threaded;
-		toggle_thread = old_value!=value;
+		toggle_thread = old_value != value;
 		i = FE_OPT_THREAD;
-	}
-	else if (exactMatch(key,config.frontend.options[FE_OPT_OVERCLOCK].key)) {
+	} else if (exactMatch(key, config.frontend.options[FE_OPT_OVERCLOCK].key)) {
 		overclock = value;
 		i = FE_OPT_OVERCLOCK;
-	}
-	else if (exactMatch(key,config.frontend.options[FE_OPT_DEBUG].key)) {
+	} else if (exactMatch(key, config.frontend.options[FE_OPT_DEBUG].key)) {
 		show_debug = value;
 		i = FE_OPT_DEBUG;
-	}
-	else if (exactMatch(key,config.frontend.options[FE_OPT_MAXFF].key)) {
+	} else if (exactMatch(key, config.frontend.options[FE_OPT_MAXFF].key)) {
 		max_ff_speed = value;
 		i = FE_OPT_MAXFF;
 	}
-	if (i==-1) return;
+	if (i == -1) return;
 	Option* option = &config.frontend.options[i];
 	option->value = value;
 }
-static void OptionList_setOptionValue(OptionList* list, const char* key, const char* value);
+static void OptionList_setOptionValue(OptionList* list, const char* key,
+									  const char* value);
 enum {
 	CONFIG_WRITE_ALL,
 	CONFIG_WRITE_GAME,
 };
 static void Config_getPath(char* filename, int override) {
 	char device_tag[64] = {0};
-	if (config.device_tag) sprintf(device_tag,"-%s",config.device_tag);
-	if (override) sprintf(filename, "%s/%s%s.cfg", core.config_dir, game.name, device_tag);
-	else sprintf(filename, "%s/minarch%s.cfg", core.config_dir, device_tag);
+	if (config.device_tag) sprintf(device_tag, "-%s", config.device_tag);
+	if (override)
+		sprintf(filename, "%s/%s%s.cfg", core.config_dir, game.name,
+				device_tag);
+	else
+		sprintf(filename, "%s/minarch%s.cfg", core.config_dir, device_tag);
 	LOG_info("Config_getPath %s\n", filename);
 }
 static void Config_init(void) {
 	if (!config.default_cfg || config.initialized) return;
-	
+
 	LOG_info("Config_init\n");
 	char* tmp = config.default_cfg;
 	char* tmp2;
 	char* key;
-	
+
 	char button_name[128];
 	char button_id[128];
 	int i = 0;
 	while ((tmp = strstr(tmp, "bind "))) {
-		tmp += 5; // tmp now points to the button name (plus the rest of the line)
+		tmp +=
+			5;	// tmp now points to the button name (plus the rest of the line)
 		key = tmp;
 		tmp = strstr(tmp, " = ");
 		if (!tmp) break;
-		
-		int len = tmp-key;
+
+		int len = tmp - key;
 		strncpy(button_name, key, len);
 		button_name[len] = '\0';
-		
+
 		tmp += 3;
 		strncpy(button_id, tmp, 128);
 		tmp2 = strchr(button_id, '\n');
 		if (!tmp2) tmp2 = strchr(button_id, '\r');
 		if (tmp2) *tmp2 = '\0';
-		
+
 		int retro_id = -1;
 		int local_id = -1;
-		
+
 		tmp2 = strrchr(button_id, ':');
 		int remap = 0;
 		if (tmp2) {
-			for (int j=0; button_label_mapping[j].name; j++) {
+			for (int j = 0; button_label_mapping[j].name; j++) {
 				ButtonMapping* button = &button_label_mapping[j];
-				if (!strcmp(tmp2+1,button->name)) {
+				if (!strcmp(tmp2 + 1, button->name)) {
 					retro_id = button->retro;
 					break;
 				}
 			}
 			*tmp2 = '\0';
 		}
-		for (int j=0; button_label_mapping[j].name; j++) {
+		for (int j = 0; button_label_mapping[j].name; j++) {
 			ButtonMapping* button = &button_label_mapping[j];
-			if (!strcmp(button_id,button->name)) {
+			if (!strcmp(button_id, button->name)) {
 				local_id = button->local;
-				if (retro_id==-1) retro_id = button->retro;
+				if (retro_id == -1) retro_id = button->retro;
 				break;
 			}
 		}
-		
-		tmp += strlen(button_id); // prepare to continue search
-		
-		LOG_info("\tbind %s (%s) %i:%i\n", button_name, button_id, local_id, retro_id);
-		
+
+		tmp += strlen(button_id);  // prepare to continue search
+
+		LOG_info("\tbind %s (%s) %i:%i\n", button_name, button_id, local_id,
+				 retro_id);
+
 		// TODO: test this without a final line return
-		tmp2 = calloc(strlen(button_name)+1, sizeof(char));
+		tmp2 = calloc(strlen(button_name) + 1, sizeof(char));
 		strcpy(tmp2, button_name);
 		ButtonMapping* button = &core_button_mapping[i++];
 		button->name = tmp2;
 		button->retro = retro_id;
 		button->local = local_id;
 	};
-	
+
 	config.initialized = 1;
 }
 static void Config_quit(void) {
 	if (!config.initialized) return;
-	for (int i=0; core_button_mapping[i].name; i++) {
+	for (int i = 0; core_button_mapping[i].name; i++) {
 		free(core_button_mapping[i].name);
 	}
 }
@@ -1110,20 +1111,21 @@ static void Config_readOptionsString(char* cfg) {
 	LOG_info("Config_readOptions\n");
 	char key[256];
 	char value[256];
-	for (int i=0; config.frontend.options[i].key; i++) {
+	for (int i = 0; config.frontend.options[i].key; i++) {
 		Option* option = &config.frontend.options[i];
 		if (!Config_getValue(cfg, option->key, value, &option->lock)) continue;
 		OptionList_setOptionValue(&config.frontend, option->key, value);
 		Config_syncFrontend(option->key, option->value);
 	}
-	
-	if (has_custom_controllers && Config_getValue(cfg,"minarch_gamepad_type",value,NULL)) {
+
+	if (has_custom_controllers &&
+		Config_getValue(cfg, "minarch_gamepad_type", value, NULL)) {
 		gamepad_type = strtol(value, NULL, 0);
 		int device = strtol(gamepad_values[gamepad_type], NULL, 0);
 		core.set_controller_port_device(0, device);
 	}
-	
-	for (int i=0; config.core.options[i].key; i++) {
+
+	for (int i = 0; config.core.options[i].key; i++) {
 		Option* option = &config.core.options[i];
 		if (!Config_getValue(cfg, option->key, value, &option->lock)) continue;
 		OptionList_setOptionValue(&config.core, option->key, value);
@@ -1133,54 +1135,55 @@ static void Config_readControlsString(char* cfg) {
 	if (!cfg) return;
 
 	LOG_info("Config_readControlsString\n");
-	
+
 	char key[256];
 	char value[256];
 	char* tmp;
-	for (int i=0; config.controls[i].name; i++) {
+	for (int i = 0; config.controls[i].name; i++) {
 		ButtonMapping* mapping = &config.controls[i];
 		sprintf(key, "bind %s", mapping->name);
 		sprintf(value, "NONE");
-		
+
 		if (!Config_getValue(cfg, key, value, NULL)) continue;
-		if ((tmp = strrchr(value, ':'))) *tmp = '\0'; // this is a binding artifact in default.cfg, ignore
-		
+		if ((tmp = strrchr(value, ':')))
+			*tmp = '\0';  // this is a binding artifact in default.cfg, ignore
+
 		int id = -1;
-		for (int j=0; button_labels[j]; j++) {
-			if (!strcmp(button_labels[j],value)) {
+		for (int j = 0; button_labels[j]; j++) {
+			if (!strcmp(button_labels[j], value)) {
 				id = j - 1;
 				break;
 			}
 		}
 		// LOG_info("\t%s (%i)\n", value, id);
-		
+
 		int mod = 0;
-		if (id>=LOCAL_BUTTON_COUNT) {
+		if (id >= LOCAL_BUTTON_COUNT) {
 			id -= LOCAL_BUTTON_COUNT;
 			mod = 1;
 		}
-		
+
 		mapping->local = id;
 		mapping->mod = mod;
 	}
-	
-	for (int i=0; config.shortcuts[i].name; i++) {
+
+	for (int i = 0; config.shortcuts[i].name; i++) {
 		ButtonMapping* mapping = &config.shortcuts[i];
 		sprintf(key, "bind %s", mapping->name);
 		sprintf(value, "NONE");
 
 		if (!Config_getValue(cfg, key, value, NULL)) continue;
-		
+
 		int id = -1;
-		for (int j=0; button_labels[j]; j++) {
-			if (!strcmp(button_labels[j],value)) {
+		for (int j = 0; button_labels[j]; j++) {
+			if (!strcmp(button_labels[j], value)) {
 				id = j - 1;
 				break;
 			}
 		}
-		
+
 		int mod = 0;
-		if (id>=LOCAL_BUTTON_COUNT) {
+		if (id >= LOCAL_BUTTON_COUNT) {
 			id -= LOCAL_BUTTON_COUNT;
 			mod = 1;
 		}
@@ -1192,10 +1195,10 @@ static void Config_readControlsString(char* cfg) {
 }
 static void Config_load(void) {
 	LOG_info("Config_load\n");
-	
+
 	config.device_tag = getenv("DEVICE");
 	LOG_info("config.device_tag %s\n", config.device_tag);
-	
+
 	// update for crop overscan support
 	Option* scaling_option = &config.frontend.options[FE_OPT_SCALING];
 	scaling_option->desc = getScreenScalingDesc();
@@ -1203,56 +1206,60 @@ static void Config_load(void) {
 	if (!GFX_supportsOverscan()) {
 		scaling_labels[3] = NULL;
 	}
-	
+
 	char* system_path = SYSTEM_PATH "/system.cfg";
-	
+
 	char device_system_path[MAX_PATH] = {0};
-	if (config.device_tag) sprintf(device_system_path, SYSTEM_PATH "/system-%s.cfg", config.device_tag);
-	
+	if (config.device_tag)
+		sprintf(device_system_path, SYSTEM_PATH "/system-%s.cfg",
+				config.device_tag);
+
 	if (config.device_tag && exists(device_system_path)) {
 		LOG_info("usng device_system_path: %s\n", device_system_path);
 		config.system_cfg = allocFile(device_system_path);
-	}
-	else if (exists(system_path)) config.system_cfg = allocFile(system_path);
-	else config.system_cfg = NULL;
-	
+	} else if (exists(system_path))
+		config.system_cfg = allocFile(system_path);
+	else
+		config.system_cfg = NULL;
+
 	// LOG_info("config.system_cfg: %s\n", config.system_cfg);
-	
+
 	char default_path[MAX_PATH];
-	getEmuPath((char *)core.tag, default_path);
+	getEmuPath((char*)core.tag, default_path);
 	char* tmp = strrchr(default_path, '/');
-	strcpy(tmp,"/default.cfg");
+	strcpy(tmp, "/default.cfg");
 
 	char device_default_path[MAX_PATH] = {0};
 	if (config.device_tag) {
-		getEmuPath((char *)core.tag, device_default_path);
+		getEmuPath((char*)core.tag, device_default_path);
 		tmp = strrchr(device_default_path, '/');
 		char filename[64];
-		sprintf(filename,"/default-%s.cfg", config.device_tag);
-		strcpy(tmp,filename);
+		sprintf(filename, "/default-%s.cfg", config.device_tag);
+		strcpy(tmp, filename);
 	}
-	
+
 	if (config.device_tag && exists(device_default_path)) {
 		LOG_info("usng device_default_path: %s\n", device_default_path);
 		config.default_cfg = allocFile(device_default_path);
-	}
-	else if (exists(default_path)) config.default_cfg = allocFile(default_path);
-	else config.default_cfg = NULL;
-	
+	} else if (exists(default_path))
+		config.default_cfg = allocFile(default_path);
+	else
+		config.default_cfg = NULL;
+
 	// LOG_info("config.default_cfg: %s\n", config.default_cfg);
-	
+
 	char path[MAX_PATH];
 	config.loaded = CONFIG_NONE;
 	int override = 0;
 	Config_getPath(path, CONFIG_WRITE_GAME);
-	if (exists(path)) override = 1; 
+	if (exists(path)) override = 1;
 	if (!override) Config_getPath(path, CONFIG_WRITE_ALL);
-	
+
 	config.user_cfg = allocFile(path);
 	if (!config.user_cfg) return;
-	
+
 	LOG_info("using user config: %s\n", path);
-	
+
 	config.loaded = override ? CONFIG_GAME : CONFIG_CONSOLE;
 }
 static void Config_free(void) {
@@ -1275,91 +1282,97 @@ static void Config_write(int override) {
 	char path[MAX_PATH];
 	// sprintf(path, "%s/%s.cfg", core.config_dir, game.name);
 	Config_getPath(path, CONFIG_WRITE_GAME);
-	
+
 	if (!override) {
-		if (config.loaded==CONFIG_GAME) unlink(path);
+		if (config.loaded == CONFIG_GAME) unlink(path);
 		Config_getPath(path, CONFIG_WRITE_ALL);
 	}
 	config.loaded = override ? CONFIG_GAME : CONFIG_CONSOLE;
-	
-	FILE *file = fopen(path, "wb");
+
+	FILE* file = fopen(path, "wb");
 	if (!file) return;
-	
-	for (int i=0; config.frontend.options[i].key; i++) {
+
+	for (int i = 0; config.frontend.options[i].key; i++) {
 		Option* option = &config.frontend.options[i];
 		fprintf(file, "%s = %s\n", option->key, option->values[option->value]);
 	}
-	for (int i=0; config.core.options[i].key; i++) {
+	for (int i = 0; config.core.options[i].key; i++) {
 		Option* option = &config.core.options[i];
 		fprintf(file, "%s = %s\n", option->key, option->values[option->value]);
 	}
-	
-	if (has_custom_controllers) fprintf(file, "%s = %i\n", "minarch_gamepad_type", gamepad_type);
-	
-	for (int i=0; config.controls[i].name; i++) {
+
+	if (has_custom_controllers)
+		fprintf(file, "%s = %i\n", "minarch_gamepad_type", gamepad_type);
+
+	for (int i = 0; config.controls[i].name; i++) {
 		ButtonMapping* mapping = &config.controls[i];
 		int j = mapping->local + 1;
 		if (mapping->mod) j += LOCAL_BUTTON_COUNT;
 		fprintf(file, "bind %s = %s\n", mapping->name, button_labels[j]);
 	}
-	for (int i=0; config.shortcuts[i].name; i++) {
+	for (int i = 0; config.shortcuts[i].name; i++) {
 		ButtonMapping* mapping = &config.shortcuts[i];
 		int j = mapping->local + 1;
 		if (mapping->mod) j += LOCAL_BUTTON_COUNT;
 		fprintf(file, "bind %s = %s\n", mapping->name, button_labels[j]);
 	}
-	
+
 	fclose(file);
 	sync();
 }
 static void Config_restore(void) {
 	char path[MAX_PATH];
-	if (config.loaded==CONFIG_GAME) {
-		if (config.device_tag) sprintf(path, "%s/%s-%s.cfg", core.config_dir, game.name, config.device_tag);
-		else sprintf(path, "%s/%s.cfg", core.config_dir, game.name);
+	if (config.loaded == CONFIG_GAME) {
+		if (config.device_tag)
+			sprintf(path, "%s/%s-%s.cfg", core.config_dir, game.name,
+					config.device_tag);
+		else
+			sprintf(path, "%s/%s.cfg", core.config_dir, game.name);
 		unlink(path);
 		LOG_info("deleted game config: %s\n", path);
-	}
-	else if (config.loaded==CONFIG_CONSOLE) {
-		if (config.device_tag) sprintf(path, "%s/minarch-%s.cfg", core.config_dir, config.device_tag);
-		else sprintf(path, "%s/minarch.cfg", core.config_dir);
+	} else if (config.loaded == CONFIG_CONSOLE) {
+		if (config.device_tag)
+			sprintf(path, "%s/minarch-%s.cfg", core.config_dir,
+					config.device_tag);
+		else
+			sprintf(path, "%s/minarch.cfg", core.config_dir);
 		unlink(path);
 		LOG_info("deleted console config: %s\n", path);
 	}
 	config.loaded = CONFIG_NONE;
-	
-	for (int i=0; config.frontend.options[i].key; i++) {
+
+	for (int i = 0; config.frontend.options[i].key; i++) {
 		Option* option = &config.frontend.options[i];
 		option->value = option->default_value;
 		Config_syncFrontend(option->key, option->value);
 	}
-	for (int i=0; config.core.options[i].key; i++) {
+	for (int i = 0; config.core.options[i].key; i++) {
 		Option* option = &config.core.options[i];
 		option->value = option->default_value;
 	}
-	config.core.changed = 1; // let the core know
-	
+	config.core.changed = 1;  // let the core know
+
 	if (has_custom_controllers) {
 		gamepad_type = 0;
 		core.set_controller_port_device(0, RETRO_DEVICE_JOYPAD);
 	}
 
-	for (int i=0; config.controls[i].name; i++) {
+	for (int i = 0; config.controls[i].name; i++) {
 		ButtonMapping* mapping = &config.controls[i];
 		mapping->local = mapping->default_;
 		mapping->mod = 0;
 	}
-	for (int i=0; config.shortcuts[i].name; i++) {
+	for (int i = 0; config.shortcuts[i].name; i++) {
 		ButtonMapping* mapping = &config.shortcuts[i];
 		mapping->local = BTN_ID_NONE;
 		mapping->mod = 0;
 	}
-	
+
 	Config_load();
 	Config_readOptions();
 	Config_readControls();
 	Config_free();
-	
+
 	renderer.dst_p = 0;
 }
 
@@ -1369,17 +1382,17 @@ static struct Special {
 } special;
 static void Special_updatedDMGPalette(int frames) {
 	// LOG_info("Special_updatedDMGPalette(%i)\n", frames);
-	special.palette_updated = frames; // must wait a few frames
+	special.palette_updated = frames;  // must wait a few frames
 }
 static void Special_refreshDMGPalette(void) {
 	special.palette_updated -= 1;
-	if (special.palette_updated>0) return;
-	
+	if (special.palette_updated > 0) return;
+
 	int rgb = getInt("/tmp/dmg_grid_color");
 	GFX_setEffectColor(rgb);
 }
 static void Special_init(void) {
-	if (special.palette_updated>1) special.palette_updated = 1;
+	if (special.palette_updated > 1) special.palette_updated = 1;
 	// else if (exactMatch((char*)core.tag, "GBC"))  {
 	// 	putInt("/tmp/dmg_grid_color",0xF79E);
 	// 	special.palette_updated = 1;
@@ -1388,14 +1401,12 @@ static void Special_init(void) {
 static void Special_render(void) {
 	if (special.palette_updated) Special_refreshDMGPalette();
 }
-static void Special_quit(void) {
-	system("rm -f /tmp/dmg_grid_color");
-}
+static void Special_quit(void) { system("rm -f /tmp/dmg_grid_color"); }
 ///////////////////////////////
 
-static  int Option_getValueIndex(Option* item, const char* value) {
+static int Option_getValueIndex(Option* item, const char* value) {
 	if (!value) return 0;
-	for (int i=0; i<item->count; i++) {
+	for (int i = 0; i < item->count; i++) {
 		if (!strcmp(item->values[i], value)) return i;
 	}
 	return 0;
@@ -1406,45 +1417,45 @@ static void Option_setValue(Option* item, const char* value) {
 }
 
 // TODO: does this also need to be applied to OptionList_vars()?
-static const char* option_key_name[] = {
-	"pcsx_rearmed_analog_combo", "DualShock Toggle Combo",
-	NULL
-};
+static const char* option_key_name[] = {"pcsx_rearmed_analog_combo",
+										"DualShock Toggle Combo", NULL};
 static const char* getOptionNameFromKey(const char* key, const char* name) {
 	char* _key = NULL;
-	for (int i=0; (_key = (char*)option_key_name[i]); i+=2) {
-		if (exactMatch((char*)key,_key)) return option_key_name[i+1];
+	for (int i = 0; (_key = (char*)option_key_name[i]); i += 2) {
+		if (exactMatch((char*)key, _key)) return option_key_name[i + 1];
 	}
 	return name;
 }
 
-// the following 3 functions always touch config.core, the rest can operate on arbitrary OptionLists
-static void OptionList_init(const struct retro_core_option_definition *defs) {
+// the following 3 functions always touch config.core, the rest can operate on
+// arbitrary OptionLists
+static void OptionList_init(const struct retro_core_option_definition* defs) {
 	LOG_info("OptionList_init\n");
 	int count;
-	for (count=0; defs[count].key; count++);
-	
+	for (count = 0; defs[count].key; count++);
+
 	// LOG_info("count: %i\n", count);
-	
-	// TODO: add frontend options to this? so the can use the same override method? eg. minarch_*
-	
+
+	// TODO: add frontend options to this? so the can use the same override
+	// method? eg. minarch_*
+
 	config.core.count = count;
 	if (count) {
-		config.core.options = calloc(count+1, sizeof(Option));
-		
-		for (int i=0; i<config.core.count; i++) {
+		config.core.options = calloc(count + 1, sizeof(Option));
+
+		for (int i = 0; i < config.core.count; i++) {
 			int len;
-			const struct retro_core_option_definition *def = &defs[i];
+			const struct retro_core_option_definition* def = &defs[i];
 			Option* item = &config.core.options[i];
 			len = strlen(def->key) + 1;
-		
+
 			item->key = calloc(len, sizeof(char));
 			strcpy(item->key, def->key);
-			
+
 			len = strlen(def->desc) + 1;
 			item->name = calloc(len, sizeof(char));
-			strcpy(item->name, getOptionNameFromKey(def->key,def->desc));
-			
+			strcpy(item->name, getOptionNameFromKey(def->key, def->desc));
+
 			if (def->info) {
 				len = strlen(def->info) + 1;
 				item->desc = calloc(len, sizeof(char));
@@ -1453,121 +1464,123 @@ static void OptionList_init(const struct retro_core_option_definition *defs) {
 				item->full = calloc(len, sizeof(char));
 				strncpy(item->full, item->desc, len);
 				// item->desc[len-1] = '\0';
-				
-				// these magic numbers are more about chars per line than pixel width 
-				// so it's not going to be relative to the screen size, only the scale
-				// what does that even mean?
-				GFX_wrapText(font.tiny, item->desc, SCALE1(240), 2); // TODO magic number!
-				GFX_wrapText(font.medium, item->full, SCALE1(240), 7); // TODO: magic number!
+
+				// these magic numbers are more about chars per line than pixel
+				// width so it's not going to be relative to the screen size,
+				// only the scale what does that even mean?
+				GFX_wrapText(font.tiny, item->desc, SCALE1(240),
+							 2);  // TODO magic number!
+				GFX_wrapText(font.medium, item->full, SCALE1(240),
+							 7);  // TODO: magic number!
 			}
-		
-			for (count=0; def->values[count].value; count++);
-		
+
+			for (count = 0; def->values[count].value; count++);
+
 			item->count = count;
-			item->values = calloc(count+1, sizeof(char*));
-			item->labels = calloc(count+1, sizeof(char*));
-	
-			for (int j=0; j<count; j++) {
+			item->values = calloc(count + 1, sizeof(char*));
+			item->labels = calloc(count + 1, sizeof(char*));
+
+			for (int j = 0; j < count; j++) {
 				const char* value = def->values[j].value;
 				const char* label = def->values[j].label;
-		
+
 				len = strlen(value) + 1;
 				item->values[j] = calloc(len, sizeof(char));
 				strcpy(item->values[j], value);
-		
+
 				if (label) {
 					len = strlen(label) + 1;
 					item->labels[j] = calloc(len, sizeof(char));
 					strcpy(item->labels[j], label);
-				}
-				else {
+				} else {
 					item->labels[j] = item->values[j];
 				}
 				// printf("\t%s\n", item->labels[j]);
 			}
-			
+
 			item->value = Option_getValueIndex(item, def->default_value);
 			item->default_value = item->value;
-			
-			// LOG_info("\tINIT %s (%s) TO %s (%s)\n", item->name, item->key, item->labels[item->value], item->values[item->value]);
+
+			// LOG_info("\tINIT %s (%s) TO %s (%s)\n", item->name, item->key,
+			// item->labels[item->value], item->values[item->value]);
 		}
 	}
 	// fflush(stdout);
 }
-static void OptionList_vars(const struct retro_variable *vars) {
+static void OptionList_vars(const struct retro_variable* vars) {
 	LOG_info("OptionList_vars\n");
 	int count;
-	for (count=0; vars[count].key; count++);
-	
+	for (count = 0; vars[count].key; count++);
+
 	config.core.count = count;
 	if (count) {
-		config.core.options = calloc(count+1, sizeof(Option));
-	
-		for (int i=0; i<config.core.count; i++) {
+		config.core.options = calloc(count + 1, sizeof(Option));
+
+		for (int i = 0; i < config.core.count; i++) {
 			int len;
-			const struct retro_variable *var = &vars[i];
+			const struct retro_variable* var = &vars[i];
 			Option* item = &config.core.options[i];
 
 			len = strlen(var->key) + 1;
 			item->key = calloc(len, sizeof(char));
 			strcpy(item->key, var->key);
-			
+
 			len = strlen(var->value) + 1;
 			item->var = calloc(len, sizeof(char));
 			strcpy(item->var, var->value);
-			
+
 			char* tmp = strchr(item->var, ';');
-			if (tmp && *(tmp+1)==' ') {
+			if (tmp && *(tmp + 1) == ' ') {
 				*tmp = '\0';
 				item->name = item->var;
 				tmp += 2;
 			}
-			
+
 			char* opt = tmp;
-			for (count=0; (tmp=strchr(tmp, '|')); tmp++, count++);
-			count += 1; // last entry after final '|'
-		
+			for (count = 0; (tmp = strchr(tmp, '|')); tmp++, count++);
+			count += 1;	 // last entry after final '|'
+
 			item->count = count;
-			item->values = calloc(count+1, sizeof(char*));
-			item->labels = calloc(count+1, sizeof(char*));
+			item->values = calloc(count + 1, sizeof(char*));
+			item->labels = calloc(count + 1, sizeof(char*));
 
 			tmp = opt;
 			int j;
-			for (j=0; (tmp=strchr(tmp, '|')); j++) {
+			for (j = 0; (tmp = strchr(tmp, '|')); j++) {
 				item->values[j] = opt;
 				item->labels[j] = opt;
 				*tmp = '\0';
 				tmp += 1;
-				opt = tmp; 
+				opt = tmp;
 			}
 			item->values[j] = opt;
 			item->labels[j] = opt;
-			
+
 			// no native default_value support for retro vars
 			item->value = 0;
 			item->default_value = item->value;
-			// printf("SET %s to %s (%i)\n", item->key, default_value, item->value); fflush(stdout);
+			// printf("SET %s to %s (%i)\n", item->key, default_value,
+			// item->value); fflush(stdout);
 		}
 	}
 	// fflush(stdout);
 }
 static void OptionList_reset(void) {
 	if (!config.core.count) return;
-	
-	for (int i=0; i<config.core.count; i++) {
+
+	for (int i = 0; i < config.core.count; i++) {
 		Option* item = &config.core.options[i];
 		if (item->var) {
 			// values/labels are all points to var
 			// so no need to free individually
 			free(item->var);
-		}
-		else {
+		} else {
 			if (item->desc) free(item->desc);
 			if (item->full) free(item->full);
-			for (int j=0; j<item->count; j++) {
+			for (int j = 0; j < item->count; j++) {
 				char* value = item->values[j];
 				char* label = item->labels[j];
-				if (label!=value) free(label);
+				if (label != value) free(label);
 				free(value);
 			}
 		}
@@ -1582,7 +1595,7 @@ static void OptionList_reset(void) {
 }
 
 static Option* OptionList_getOption(OptionList* list, const char* key) {
-	for (int i=0; i<list->count; i++) {
+	for (int i = 0; i < list->count; i++) {
 		Option* item = &list->options[i];
 		if (!strcmp(item->key, key)) return item;
 	}
@@ -1590,40 +1603,51 @@ static Option* OptionList_getOption(OptionList* list, const char* key) {
 }
 static char* OptionList_getOptionValue(OptionList* list, const char* key) {
 	Option* item = OptionList_getOption(list, key);
-	// if (item) LOG_info("\tGET %s (%s) = %s (%s)\n", item->name, item->key, item->labels[item->value], item->values[item->value]);
-	
-	if (item) return item->values[item->value];
-	else LOG_warn("unknown option %s \n", key);
+	// if (item) LOG_info("\tGET %s (%s) = %s (%s)\n", item->name, item->key,
+	// item->labels[item->value], item->values[item->value]);
+
+	if (item)
+		return item->values[item->value];
+	else
+		LOG_warn("unknown option %s \n", key);
 	return NULL;
 }
-static void OptionList_setOptionRawValue(OptionList* list, const char* key, int value) {
+static void OptionList_setOptionRawValue(OptionList* list, const char* key,
+										 int value) {
 	Option* item = OptionList_getOption(list, key);
 	if (item) {
 		item->value = value;
 		list->changed = 1;
-		// LOG_info("\tRAW SET %s (%s) TO %s (%s)\n", item->name, item->key, item->labels[item->value], item->values[item->value]);
-		// if (list->on_set) list->on_set(list, key);
+		// LOG_info("\tRAW SET %s (%s) TO %s (%s)\n", item->name, item->key,
+		// item->labels[item->value], item->values[item->value]); if
+		// (list->on_set) list->on_set(list, key);
 
-		if (exactMatch((char*)core.tag, "GB") && containsString(item->key, "palette")) Special_updatedDMGPalette(3); // from options
-	}
-	else LOG_info("unknown option %s \n", key);
+		if (exactMatch((char*)core.tag, "GB") &&
+			containsString(item->key, "palette"))
+			Special_updatedDMGPalette(3);  // from options
+	} else
+		LOG_info("unknown option %s \n", key);
 }
-static void OptionList_setOptionValue(OptionList* list, const char* key, const char* value) {
+static void OptionList_setOptionValue(OptionList* list, const char* key,
+									  const char* value) {
 	Option* item = OptionList_getOption(list, key);
 	if (item) {
 		Option_setValue(item, value);
 		list->changed = 1;
-		// LOG_info("\tSET %s (%s) TO %s (%s)\n", item->name, item->key, item->labels[item->value], item->values[item->value]);
-		// if (list->on_set) list->on_set(list, key);
-		
-		if (exactMatch((char*)core.tag, "GB") && containsString(item->key, "palette")) Special_updatedDMGPalette(2); // from core
-	}
-	else LOG_info("unknown option %s \n", key);
+		// LOG_info("\tSET %s (%s) TO %s (%s)\n", item->name, item->key,
+		// item->labels[item->value], item->values[item->value]); if
+		// (list->on_set) list->on_set(list, key);
+
+		if (exactMatch((char*)core.tag, "GB") &&
+			containsString(item->key, "palette"))
+			Special_updatedDMGPalette(2);  // from core
+	} else
+		LOG_info("unknown option %s \n", key);
 }
-// static void OptionList_setOptionVisibility(OptionList* list, const char* key, int visible) {
-// 	Option* item = OptionList_getOption(list, key);
-// 	if (item) item->visible = visible;
-// 	else printf("unknown option %s \n", key); fflush(stdout);
+// static void OptionList_setOptionVisibility(OptionList* list, const char* key,
+// int visible) { 	Option* item = OptionList_getOption(list, key); 	if
+// (item) item->visible = visible; 	else printf("unknown option %s \n", key);
+// fflush(stdout);
 // }
 
 ///////////////////////////////
@@ -1639,8 +1663,7 @@ static int setFastForward(int enable) {
 		// LOG_info("entered fast forward with threaded core...\n");
 		was_threaded = 1;
 		toggle_thread = 1;
-	}
-	else if (fast_forward && !enable && !thread_video && was_threaded) {
+	} else if (fast_forward && !enable && !thread_video && was_threaded) {
 		// LOG_info("exited fast forward with previously threaded core...\n");
 		was_threaded = 0;
 		toggle_thread = 1;
@@ -1649,7 +1672,7 @@ static int setFastForward(int enable) {
 	return enable;
 }
 
-static uint32_t buttons = 0; // RETRO_DEVICE_ID_JOYPAD_* buttons
+static uint32_t buttons = 0;  // RETRO_DEVICE_ID_JOYPAD_* buttons
 static int ignore_menu = 0;
 static void input_poll_callback(void) {
 	PAD_poll();
@@ -1661,88 +1684,102 @@ static void input_poll_callback(void) {
 	if (PAD_justPressed(BTN_MENU)) {
 		ignore_menu = 0;
 	}
-	if (PAD_isPressed(BTN_MENU) && (PAD_isPressed(BTN_PLUS) || PAD_isPressed(BTN_MINUS))) {
+	if (PAD_isPressed(BTN_MENU) &&
+		(PAD_isPressed(BTN_PLUS) || PAD_isPressed(BTN_MINUS))) {
 		ignore_menu = 1;
 	}
-	
+
 	if (PAD_justPressed(BTN_POWER)) {
 		if (thread_video) {
 			// LOG_info("pressed power with threaded core...\n");
 			was_threaded = 1;
 			toggle_thread = 1;
 		}
-	}
-	else if (PAD_justReleased(BTN_POWER)) {
+	} else if (PAD_justReleased(BTN_POWER)) {
 		if (!thread_video && was_threaded) {
-			// LOG_info("released power with previously threaded core before power off...\n");
+			// LOG_info("released power with previously threaded core before
+			// power off...\n");
 			was_threaded = 0;
 			toggle_thread = 1;
 		}
 	}
-	
-	static int toggled_ff_on = 0; // this logic only works because TOGGLE_FF is before HOLD_FF in the menu...
-	for (int i=0; i<SHORTCUT_COUNT; i++) {
+
+	static int toggled_ff_on = 0;  // this logic only works because TOGGLE_FF is
+								   // before HOLD_FF in the menu...
+	for (int i = 0; i < SHORTCUT_COUNT; i++) {
 		ButtonMapping* mapping = &config.shortcuts[i];
 		int btn = 1 << mapping->local;
-		if (btn==BTN_NONE) continue; // not bound
+		if (btn == BTN_NONE) continue;	// not bound
 		if (!mapping->mod || PAD_isPressed(BTN_MENU)) {
-			if (i==SHORTCUT_TOGGLE_FF) {
+			if (i == SHORTCUT_TOGGLE_FF) {
 				if (PAD_justPressed(btn)) {
 					toggled_ff_on = setFastForward(!fast_forward);
 					if (mapping->mod) ignore_menu = 1;
 					break;
-				}
-				else if (PAD_justReleased(btn)) {
+				} else if (PAD_justReleased(btn)) {
 					if (mapping->mod) ignore_menu = 1;
 					break;
 				}
-			}
-			else if (i==SHORTCUT_HOLD_FF) {
-				// don't allow turn off fast_forward with a release of the hold button 
-				// if it was initially turned on with the toggle button
-				if (PAD_justPressed(btn) || (!toggled_ff_on && PAD_justReleased(btn))) {
+			} else if (i == SHORTCUT_HOLD_FF) {
+				// don't allow turn off fast_forward with a release of the hold
+				// button if it was initially turned on with the toggle button
+				if (PAD_justPressed(btn) ||
+					(!toggled_ff_on && PAD_justReleased(btn))) {
 					fast_forward = setFastForward(PAD_isPressed(btn));
-					if (mapping->mod) ignore_menu = 1; // very unlikely but just in case
+					if (mapping->mod)
+						ignore_menu = 1;  // very unlikely but just in case
 				}
-			}
-			else if (PAD_justPressed(btn)) {
+			} else if (PAD_justPressed(btn)) {
 				switch (i) {
-					case SHORTCUT_SAVE_STATE: Menu_saveState(); break;
-					case SHORTCUT_LOAD_STATE: Menu_loadState(); break;
-					case SHORTCUT_RESET_GAME: core.reset(); break;
+					case SHORTCUT_SAVE_STATE:
+						Menu_saveState();
+						break;
+					case SHORTCUT_LOAD_STATE:
+						Menu_loadState();
+						break;
+					case SHORTCUT_RESET_GAME:
+						core.reset();
+						break;
 					case SHORTCUT_SAVE_QUIT:
 						Menu_saveState();
 						quit = 1;
 						break;
 					case SHORTCUT_CYCLE_SCALE:
 						screen_scaling += 1;
-						int count = config.frontend.options[FE_OPT_SCALING].count;
-						if (screen_scaling>=count) screen_scaling -= count;
-						Config_syncFrontend(config.frontend.options[FE_OPT_SCALING].key, screen_scaling);
+						int count =
+							config.frontend.options[FE_OPT_SCALING].count;
+						if (screen_scaling >= count) screen_scaling -= count;
+						Config_syncFrontend(
+							config.frontend.options[FE_OPT_SCALING].key,
+							screen_scaling);
 						break;
 					case SHORTCUT_CYCLE_EFFECT:
 						screen_effect += 1;
-						if (screen_effect>=EFFECT_COUNT) screen_effect -= EFFECT_COUNT;
-						Config_syncFrontend(config.frontend.options[FE_OPT_EFFECT].key, screen_effect);
+						if (screen_effect >= EFFECT_COUNT)
+							screen_effect -= EFFECT_COUNT;
+						Config_syncFrontend(
+							config.frontend.options[FE_OPT_EFFECT].key,
+							screen_effect);
 						break;
-					default: break;
+					default:
+						break;
 				}
-				
+
 				if (mapping->mod) ignore_menu = 1;
 			}
 		}
 	}
-	
+
 	if (!ignore_menu && PAD_justReleased(BTN_MENU)) {
 		show_menu = 1;
-		
+
 		if (thread_video) {
 			pthread_mutex_lock(&core_mx);
 			should_run_core = 0;
 			pthread_mutex_unlock(&core_mx);
 		}
 	}
-	
+
 	// TODO: figure out how to ignore button when MENU+button is handled first
 	// TODO: array size of LOCAL_ whatever that macro is
 	// TODO: then split it into two loops
@@ -1751,18 +1788,26 @@ static void input_poll_callback(void) {
 	// TODO: then check for button
 	// TODO: only modify if absent from array
 	// TODO: the shortcuts loop above should also contribute to the array
-	
+
 	buttons = 0;
-	for (int i=0; config.controls[i].name; i++) {
+	for (int i = 0; config.controls[i].name; i++) {
 		ButtonMapping* mapping = &config.controls[i];
 		int btn = 1 << mapping->local;
-		if (btn==BTN_NONE) continue; // present buttons can still be unbound
-		if (gamepad_type==0) {
-			switch(btn) {
-				case BTN_DPAD_UP: 		btn = BTN_UP; break;
-				case BTN_DPAD_DOWN: 	btn = BTN_DOWN; break;
-				case BTN_DPAD_LEFT: 	btn = BTN_LEFT; break;
-				case BTN_DPAD_RIGHT: 	btn = BTN_RIGHT; break;
+		if (btn == BTN_NONE) continue;	// present buttons can still be unbound
+		if (gamepad_type == 0) {
+			switch (btn) {
+				case BTN_DPAD_UP:
+					btn = BTN_UP;
+					break;
+				case BTN_DPAD_DOWN:
+					btn = BTN_DOWN;
+					break;
+				case BTN_DPAD_LEFT:
+					btn = BTN_LEFT;
+					break;
+				case BTN_DPAD_RIGHT:
+					btn = BTN_RIGHT;
+					break;
 			}
 		}
 		if (PAD_isPressed(btn) && (!mapping->mod || PAD_isPressed(BTN_MENU))) {
@@ -1771,36 +1816,40 @@ static void input_poll_callback(void) {
 		}
 		//  && !PWR_ignoreSettingInput(btn, show_setting)
 	}
-	
+
 	// if (buttons) LOG_info("buttons: %i\n", buttons);
 }
-static int16_t input_state_callback(unsigned port, unsigned device, unsigned index, unsigned id) {
-	if (port==0 && device==RETRO_DEVICE_JOYPAD && index==0) {
+static int16_t input_state_callback(unsigned port, unsigned device,
+									unsigned index, unsigned id) {
+	if (port == 0 && device == RETRO_DEVICE_JOYPAD && index == 0) {
 		if (id == RETRO_DEVICE_ID_JOYPAD_MASK) return buttons;
 		return (buttons >> id) & 1;
-	}
-	else if (port==0 && device==RETRO_DEVICE_ANALOG) {
-		if (index==RETRO_DEVICE_INDEX_ANALOG_LEFT) {
-			if (id==RETRO_DEVICE_ID_ANALOG_X) return pad.laxis.x;
-			else if (id==RETRO_DEVICE_ID_ANALOG_Y) return pad.laxis.y;
-		}
-		else if (index==RETRO_DEVICE_INDEX_ANALOG_RIGHT) {
-			if (id==RETRO_DEVICE_ID_ANALOG_X) return pad.raxis.x;
-			else if (id==RETRO_DEVICE_ID_ANALOG_Y) return pad.raxis.y;
+	} else if (port == 0 && device == RETRO_DEVICE_ANALOG) {
+		if (index == RETRO_DEVICE_INDEX_ANALOG_LEFT) {
+			if (id == RETRO_DEVICE_ID_ANALOG_X)
+				return pad.laxis.x;
+			else if (id == RETRO_DEVICE_ID_ANALOG_Y)
+				return pad.laxis.y;
+		} else if (index == RETRO_DEVICE_INDEX_ANALOG_RIGHT) {
+			if (id == RETRO_DEVICE_ID_ANALOG_X)
+				return pad.raxis.x;
+			else if (id == RETRO_DEVICE_ID_ANALOG_Y)
+				return pad.raxis.y;
 		}
 	}
 	return 0;
 }
 ///////////////////////////////
 
-static void Input_init(const struct retro_input_descriptor *vars) {
+static void Input_init(const struct retro_input_descriptor* vars) {
 	static int input_initialized = 0;
 	if (input_initialized) return;
 
 	LOG_info("Input_init\n");
-	
-	config.controls = core_button_mapping[0].name ? core_button_mapping : default_button_mapping;
-	
+
+	config.controls = core_button_mapping[0].name ? core_button_mapping
+												  : default_button_mapping;
+
 	puts("---------------------------------");
 
 	const char* core_button_names[RETRO_BUTTON_COUNT] = {0};
@@ -1809,34 +1858,43 @@ static void Input_init(const struct retro_input_descriptor *vars) {
 	if (vars) {
 		core_mapped = 1;
 		// identify buttons available in this core
-		for (int i=0; vars[i].description; i++) {
+		for (int i = 0; vars[i].description; i++) {
 			const struct retro_input_descriptor* var = &vars[i];
-			if (var->port!=0 || var->device!=RETRO_DEVICE_JOYPAD || var->index!=0) continue;
-
-			// TODO: don't ignore unavailable buttons, just override them to BTN_ID_NONE!
-			if (var->id>=RETRO_BUTTON_COUNT) {
-				printf("UNAVAILABLE: %s\n", var->description); fflush(stdout);
+			if (var->port != 0 || var->device != RETRO_DEVICE_JOYPAD ||
+				var->index != 0)
 				continue;
-			}
-			else {
-				printf("PRESENT    : %s\n", var->description); fflush(stdout);
+
+			// TODO: don't ignore unavailable buttons, just override them to
+			// BTN_ID_NONE!
+			if (var->id >= RETRO_BUTTON_COUNT) {
+				printf("UNAVAILABLE: %s\n", var->description);
+				fflush(stdout);
+				continue;
+			} else {
+				printf("PRESENT    : %s\n", var->description);
+				fflush(stdout);
 			}
 			present[var->id] = 1;
 			core_button_names[var->id] = var->description;
 		}
 	}
-	
+
 	puts("---------------------------------");
 
-	for (int i=0;default_button_mapping[i].name; i++) {
+	for (int i = 0; default_button_mapping[i].name; i++) {
 		ButtonMapping* mapping = &default_button_mapping[i];
-		LOG_info("DEFAULT %s (%s): <%s>\n", core_button_names[mapping->retro], mapping->name, (mapping->local==BTN_ID_NONE ? "NONE" : device_button_names[mapping->local]));
-		if (core_button_names[mapping->retro]) mapping->name = (char*)core_button_names[mapping->retro];
+		LOG_info("DEFAULT %s (%s): <%s>\n", core_button_names[mapping->retro],
+				 mapping->name,
+				 (mapping->local == BTN_ID_NONE
+					  ? "NONE"
+					  : device_button_names[mapping->local]));
+		if (core_button_names[mapping->retro])
+			mapping->name = (char*)core_button_names[mapping->retro];
 	}
-	
+
 	puts("---------------------------------");
 
-	for (int i=0; config.controls[i].name; i++) {
+	for (int i = 0; config.controls[i].name; i++) {
 		ButtonMapping* mapping = &config.controls[i];
 		mapping->default_ = mapping->local;
 
@@ -1845,310 +1903,341 @@ static void Input_init(const struct retro_input_descriptor *vars) {
 			mapping->ignore = 1;
 			continue;
 		}
-		LOG_info("%s: <%s> (%i:%i)\n", mapping->name, (mapping->local==BTN_ID_NONE ? "NONE" : device_button_names[mapping->local]), mapping->local, mapping->retro);
+		LOG_info("%s: <%s> (%i:%i)\n", mapping->name,
+				 (mapping->local == BTN_ID_NONE
+					  ? "NONE"
+					  : device_button_names[mapping->local]),
+				 mapping->local, mapping->retro);
 	}
-	
+
 	puts("---------------------------------");
 	input_initialized = 1;
 }
 
-static bool set_rumble_state(unsigned port, enum retro_rumble_effect effect, uint16_t strength) {
+static bool set_rumble_state(unsigned port, enum retro_rumble_effect effect,
+							 uint16_t strength) {
 	// TODO: handle other args? not sure I can
 	VIB_setStrength(strength);
 	return 1;
 }
-static bool environment_callback(unsigned cmd, void *data) { // copied from picoarch initially
+static bool environment_callback(
+	unsigned cmd, void* data) {	 // copied from picoarch initially
 	// LOG_info("environment_callback: %i\n", cmd);
-	
-	switch(cmd) {
-	case RETRO_ENVIRONMENT_GET_OVERSCAN: { /* 2 */
-		bool *out = (bool *)data;
-		if (out)
-			*out = true;
-		break;
-	}
-	case RETRO_ENVIRONMENT_GET_CAN_DUPE: { /* 3 */
-		bool *out = (bool *)data;
-		if (out)
-			*out = true;
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_MESSAGE: { /* 6 */
-		const struct retro_message *message = (const struct retro_message*)data;
-		if (message) LOG_info("%s\n", message->msg);
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL: { /* 8 */
-		// puts("RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL");
-		// TODO: used by fceumm at least
-	}
-	case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY: { /* 9 */
-		const char **out = (const char **)data;
-		if (out) {
-			*out = core.bios_dir;
-		}
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT: { /* 10 */
-		const enum retro_pixel_format *format = (enum retro_pixel_format *)data;
 
-		if (*format != RETRO_PIXEL_FORMAT_RGB565) { // TODO: pull from platform.h?
-			/* 565 is only supported format */
-			return false;
-			// downsample = 1; // TODO: not ready for primetime yet
+	switch (cmd) {
+		case RETRO_ENVIRONMENT_GET_OVERSCAN: { /* 2 */
+			bool* out = (bool*)data;
+			if (out) *out = true;
+			break;
 		}
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS: { /* 11 */
-		// puts("RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS\n");
-		Input_init((const struct retro_input_descriptor *)data);
-		return false;
-	} break;
-	case RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE: { /* 13 */
-		const struct retro_disk_control_callback *var =
-			(const struct retro_disk_control_callback *)data;
-
-		if (var) {
-			memset(&disk_control_ext, 0, sizeof(struct retro_disk_control_ext_callback));
-			memcpy(&disk_control_ext, var, sizeof(struct retro_disk_control_callback));
+		case RETRO_ENVIRONMENT_GET_CAN_DUPE: { /* 3 */
+			bool* out = (bool*)data;
+			if (out) *out = true;
+			break;
 		}
-		break;
-	}
-
-	// TODO: this is called whether using variables or options
-	case RETRO_ENVIRONMENT_GET_VARIABLE: { /* 15 */
-		// puts("RETRO_ENVIRONMENT_GET_VARIABLE ");
-		struct retro_variable *var = (struct retro_variable *)data;
-		if (var && var->key) {
-			var->value = OptionList_getOptionValue(&config.core, var->key);
-			// printf("\t%s = %s\n", var->key, var->value);
+		case RETRO_ENVIRONMENT_SET_MESSAGE: { /* 6 */
+			const struct retro_message* message =
+				(const struct retro_message*)data;
+			if (message) LOG_info("%s\n", message->msg);
+			break;
 		}
-		// fflush(stdout);
-		break;
-	}
-	// TODO: I think this is where the core reports its variables (the precursor to options)
-	// TODO: this is called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION sets out to 0
-	// TODO: not used by anything yet
-	case RETRO_ENVIRONMENT_SET_VARIABLES: { /* 16 */
-		// puts("RETRO_ENVIRONMENT_SET_VARIABLES");
-		const struct retro_variable *vars = (const struct retro_variable *)data;
-		if (vars) {
-			OptionList_reset();
-			OptionList_vars(vars);
+		case RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL: { /* 8 */
+			// puts("RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL");
+			// TODO: used by fceumm at least
 		}
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME: { /* 18 */
-		bool flag = *(bool*)data;
-		// LOG_info("%i: RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME: %i\n", cmd, flag);
-		break;
-	}
-	case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE: { /* 17 */
-		bool *out = (bool *)data;
-		if (out) {
-			*out = config.core.changed;
-			config.core.changed = 0;
-		}
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK: { /* 21 */
-		// LOG_info("%i: RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK\n", cmd);
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK: { /* 22 */
-		// LOG_info("%i: RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK\n", cmd);
-		break;
-	}
-	case RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE: { /* 23 */
-	        struct retro_rumble_interface *iface = (struct retro_rumble_interface*)data;
-
-	        // LOG_info("Setup rumble interface.\n");
-	        iface->set_rumble_state = set_rumble_state;
-		break;
-	}
-	case RETRO_ENVIRONMENT_GET_INPUT_DEVICE_CAPABILITIES: {
-		unsigned *out = (unsigned *)data;
-		if (out)
-			*out = (1 << RETRO_DEVICE_JOYPAD) | (1 << RETRO_DEVICE_ANALOG);
-		break;
-	}
-	case RETRO_ENVIRONMENT_GET_LOG_INTERFACE: { /* 27 */
-		struct retro_log_callback *log_cb = (struct retro_log_callback *)data;
-		if (log_cb)
-			log_cb->log = (void (*)(enum retro_log_level, const char*, ...))LOG_note; // same difference
-		break;
-	}
-	case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY: { /* 31 */
-		const char **out = (const char **)data;
-		if (out)
-			*out = core.saves_dir; // save_dir;
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_CONTROLLER_INFO: { /* 35 */
-		// LOG_info("RETRO_ENVIRONMENT_SET_CONTROLLER_INFO\n");
-		const struct retro_controller_info *infos = (const struct retro_controller_info *)data;
-		if (infos) {
-			// TODO: store to gamepad_values/gamepad_labels for gamepad_device
-			const struct retro_controller_info *info = &infos[0];
-			for (int i=0; i<info->num_types; i++) {
-				const struct retro_controller_description *type = &info->types[i];
-				if (exactMatch((char*)type->desc,"dualshock")) { // currently only enabled for PlayStation
-					has_custom_controllers = 1;
-					break;
-				}
-				// printf("\t%i: %s\n", type->id, type->desc);
+		case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY: { /* 9 */
+			const char** out = (const char**)data;
+			if (out) {
+				*out = core.bios_dir;
 			}
+			break;
 		}
-		fflush(stdout);
-		return false; // TODO: tmp
-		break;
-	}
-	// RETRO_ENVIRONMENT_SET_MEMORY_MAPS (36 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-	// RETRO_ENVIRONMENT_GET_LANGUAGE 39
-	case RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER: { /* (40 | RETRO_ENVIRONMENT_EXPERIMENTAL) */
-		// puts("RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER");
-		break;
-	}
-	
-	case RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE: {
-		// fixes fbneo save state graphics corruption
-		// puts("RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE");
-		int *out_p = (int *)data;
-		if (out_p) {
-			int out = 0;
-			out |= RETRO_AV_ENABLE_VIDEO;
-			out |= RETRO_AV_ENABLE_AUDIO;
-			*out_p = out;
-		}
-		break;
-	}
-	
-	// RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS (42 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-	// RETRO_ENVIRONMENT_GET_VFS_INTERFACE (45 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-	// RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-	// RETRO_ENVIRONMENT_GET_INPUT_BITMASKS (51 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-	case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS: { /* 51 | RETRO_ENVIRONMENT_EXPERIMENTAL */
-		bool *out = (bool *)data;
-		if (out)
-			*out = true;
-		break;
-	}
-	case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION: { /* 52 */
-		// puts("RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION");
-		unsigned *out = (unsigned *)data;
-		if (out)
-			*out = 1;
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_CORE_OPTIONS: { /* 53 */
-		// puts("RETRO_ENVIRONMENT_SET_CORE_OPTIONS");
-		if (data) {
-			OptionList_reset();
-			OptionList_init((const struct retro_core_option_definition *)data); 
-		}
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL: { /* 54 */
-		// puts("RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL");
-		const struct retro_core_options_intl *options = (const struct retro_core_options_intl *)data;
-		if (options && options->us) {
-			OptionList_reset();
-			OptionList_init(options->us);
-		}
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY: { /* 55 */
-		// puts("RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY");
-		// const struct retro_core_option_display *display = (const struct retro_core_option_display *)data;
-	// 	if (display) OptionList_setOptionVisibility(&config.core, display->key, display->visible);
-		break;
-	}
-	case RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION: { /* 57 */
-		unsigned *out =	(unsigned *)data;
-		if (out) *out = 1;
-		break;
-	}
-	case RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE: { /* 58 */
-		const struct retro_disk_control_ext_callback *var =
-			(const struct retro_disk_control_ext_callback *)data;
+		case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT: { /* 10 */
+			const enum retro_pixel_format* format =
+				(enum retro_pixel_format*)data;
 
-		if (var) {
-			memcpy(&disk_control_ext, var, sizeof(struct retro_disk_control_ext_callback));
+			if (*format !=
+				RETRO_PIXEL_FORMAT_RGB565) {  // TODO: pull from platform.h?
+				/* 565 is only supported format */
+				return false;
+				// downsample = 1; // TODO: not ready for primetime yet
+			}
+			break;
 		}
-		break;
-	}
-	// TODO: RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION 59
-	// TODO: used by mgba, (but only during frameskip?)
-	// case RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK: { /* 62 */
-	// 	LOG_info("RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK\n");
-	// 	const struct retro_audio_buffer_status_callback *cb = (const struct retro_audio_buffer_status_callback *)data;
-	// 	if (cb) {
-	// 		LOG_info("has audo_buffer_status callback\n");
-	// 		core.audio_buffer_status = cb->callback;
-	// 	} else {
-	// 		LOG_info("no audo_buffer_status callback\n");
-	// 		core.audio_buffer_status = NULL;
-	// 	}
-	// 	break;
-	// }
-	// TODO: used by mgba, (but only during frameskip?)
-	// case RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY: { /* 63 */
-	// 	LOG_info("RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY\n");
-	//
-	// 	const unsigned *latency_ms = (const unsigned *)data;
-	// 	if (latency_ms) {
-	// 		unsigned frames = *latency_ms * core.fps / 1000;
-	// 		if (frames < 30)
-	// 			// audio_buffer_size_override = frames;
-	// 			LOG_info("audio_buffer_size_override = %i (unused?)\n", frames);
-	// 		else
-	// 			LOG_info("Audio buffer change out of range (%d), ignored\n", frames);
-	// 	}
-	// 	break;
-	// }
+		case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS: { /* 11 */
+			// puts("RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS\n");
+			Input_init((const struct retro_input_descriptor*)data);
+			return false;
+		} break;
+		case RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE: { /* 13 */
+			const struct retro_disk_control_callback* var =
+				(const struct retro_disk_control_callback*)data;
 
-	// TODO: RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
-	case RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE: { /* 65 */
-		// const struct retro_system_content_info_override* info = (const struct retro_system_content_info_override* )data;
-		// if (info) LOG_info("has overrides");
-		break;
-	}
-	// RETRO_ENVIRONMENT_GET_GAME_INFO_EXT 66
-	// TODO: RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK 69
-	// used by fceumm
-	// TODO: used by gambatte for L/R palette switching (seems like it needs to return true even if data is NULL to indicate support)
-	case RETRO_ENVIRONMENT_SET_VARIABLE: {
-		// puts("RETRO_ENVIRONMENT_SET_VARIABLE");
-		const struct retro_variable *var = (const struct retro_variable *)data;
-		if (var && var->key) {
-			// printf("\t%s = %s\n", var->key, var->value);
-			OptionList_setOptionValue(&config.core, var->key, var->value);
+			if (var) {
+				memset(&disk_control_ext, 0,
+					   sizeof(struct retro_disk_control_ext_callback));
+				memcpy(&disk_control_ext, var,
+					   sizeof(struct retro_disk_control_callback));
+			}
 			break;
 		}
 
-		int *out = (int *)data;
-		if (out) *out = 1;
-		
-		break;
-	}
-	
-	// unused
-	// case RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK: {
-	// 	puts("RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK"); fflush(stdout);
-	// 	break;
-	// }
-	// case RETRO_ENVIRONMENT_GET_THROTTLE_STATE: {
-	// 	puts("RETRO_ENVIRONMENT_GET_THROTTLE_STATE"); fflush(stdout);
-	// 	break;
-	// }
-	// case RETRO_ENVIRONMENT_GET_FASTFORWARDING: {
-	// 	puts("RETRO_ENVIRONMENT_GET_FASTFORWARDING"); fflush(stdout);
-	// 	break;
-	// };
-	
-	default:
-		// LOG_debug("Unsupported environment cmd: %u\n", cmd);
-		return false;
+		// TODO: this is called whether using variables or options
+		case RETRO_ENVIRONMENT_GET_VARIABLE: { /* 15 */
+			// puts("RETRO_ENVIRONMENT_GET_VARIABLE ");
+			struct retro_variable* var = (struct retro_variable*)data;
+			if (var && var->key) {
+				var->value = OptionList_getOptionValue(&config.core, var->key);
+				// printf("\t%s = %s\n", var->key, var->value);
+			}
+			// fflush(stdout);
+			break;
+		}
+		// TODO: I think this is where the core reports its variables (the
+		// precursor to options)
+		// TODO: this is called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+		// sets out to 0
+		// TODO: not used by anything yet
+		case RETRO_ENVIRONMENT_SET_VARIABLES: { /* 16 */
+			// puts("RETRO_ENVIRONMENT_SET_VARIABLES");
+			const struct retro_variable* vars =
+				(const struct retro_variable*)data;
+			if (vars) {
+				OptionList_reset();
+				OptionList_vars(vars);
+			}
+			break;
+		}
+		case RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME: { /* 18 */
+			bool flag = *(bool*)data;
+			// LOG_info("%i: RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME: %i\n", cmd,
+			// flag);
+			break;
+		}
+		case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE: { /* 17 */
+			bool* out = (bool*)data;
+			if (out) {
+				*out = config.core.changed;
+				config.core.changed = 0;
+			}
+			break;
+		}
+		case RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK: { /* 21 */
+			// LOG_info("%i: RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK\n", cmd);
+			break;
+		}
+		case RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK: { /* 22 */
+			// LOG_info("%i: RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK\n", cmd);
+			break;
+		}
+		case RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE: { /* 23 */
+			struct retro_rumble_interface* iface =
+				(struct retro_rumble_interface*)data;
+
+			// LOG_info("Setup rumble interface.\n");
+			iface->set_rumble_state = set_rumble_state;
+			break;
+		}
+		case RETRO_ENVIRONMENT_GET_INPUT_DEVICE_CAPABILITIES: {
+			unsigned* out = (unsigned*)data;
+			if (out)
+				*out = (1 << RETRO_DEVICE_JOYPAD) | (1 << RETRO_DEVICE_ANALOG);
+			break;
+		}
+		case RETRO_ENVIRONMENT_GET_LOG_INTERFACE: { /* 27 */
+			struct retro_log_callback* log_cb =
+				(struct retro_log_callback*)data;
+			if (log_cb)
+				log_cb->log = (void (*)(enum retro_log_level, const char*,
+										...))LOG_note;	// same difference
+			break;
+		}
+		case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY: { /* 31 */
+			const char** out = (const char**)data;
+			if (out) *out = core.saves_dir;	 // save_dir;
+			break;
+		}
+		case RETRO_ENVIRONMENT_SET_CONTROLLER_INFO: { /* 35 */
+			// LOG_info("RETRO_ENVIRONMENT_SET_CONTROLLER_INFO\n");
+			const struct retro_controller_info* infos =
+				(const struct retro_controller_info*)data;
+			if (infos) {
+				// TODO: store to gamepad_values/gamepad_labels for
+				// gamepad_device
+				const struct retro_controller_info* info = &infos[0];
+				for (int i = 0; i < info->num_types; i++) {
+					const struct retro_controller_description* type =
+						&info->types[i];
+					if (exactMatch((char*)type->desc,
+								   "dualshock")) {	// currently only enabled
+													// for PlayStation
+						has_custom_controllers = 1;
+						break;
+					}
+					// printf("\t%i: %s\n", type->id, type->desc);
+				}
+			}
+			fflush(stdout);
+			return false;  // TODO: tmp
+			break;
+		}
+		// RETRO_ENVIRONMENT_SET_MEMORY_MAPS (36 |
+		// RETRO_ENVIRONMENT_EXPERIMENTAL) RETRO_ENVIRONMENT_GET_LANGUAGE 39
+		case RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER: { /* (40 |
+																	  RETRO_ENVIRONMENT_EXPERIMENTAL)
+																	*/
+			// puts("RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER");
+			break;
+		}
+
+		case RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE: {
+			// fixes fbneo save state graphics corruption
+			// puts("RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE");
+			int* out_p = (int*)data;
+			if (out_p) {
+				int out = 0;
+				out |= RETRO_AV_ENABLE_VIDEO;
+				out |= RETRO_AV_ENABLE_AUDIO;
+				*out_p = out;
+			}
+			break;
+		}
+
+		// RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS (42 |
+		// RETRO_ENVIRONMENT_EXPERIMENTAL) RETRO_ENVIRONMENT_GET_VFS_INTERFACE
+		// (45 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+		// RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 |
+		// RETRO_ENVIRONMENT_EXPERIMENTAL) RETRO_ENVIRONMENT_GET_INPUT_BITMASKS
+		// (51 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+		case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS: { /* 51 |
+														RETRO_ENVIRONMENT_EXPERIMENTAL
+													  */
+			bool* out = (bool*)data;
+			if (out) *out = true;
+			break;
+		}
+		case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION: { /* 52 */
+			// puts("RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION");
+			unsigned* out = (unsigned*)data;
+			if (out) *out = 1;
+			break;
+		}
+		case RETRO_ENVIRONMENT_SET_CORE_OPTIONS: { /* 53 */
+			// puts("RETRO_ENVIRONMENT_SET_CORE_OPTIONS");
+			if (data) {
+				OptionList_reset();
+				OptionList_init(
+					(const struct retro_core_option_definition*)data);
+			}
+			break;
+		}
+		case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL: { /* 54 */
+			// puts("RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL");
+			const struct retro_core_options_intl* options =
+				(const struct retro_core_options_intl*)data;
+			if (options && options->us) {
+				OptionList_reset();
+				OptionList_init(options->us);
+			}
+			break;
+		}
+		case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY: { /* 55 */
+			// puts("RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY");
+			// const struct retro_core_option_display *display = (const struct
+			// retro_core_option_display *)data;
+			// 	if (display) OptionList_setOptionVisibility(&config.core,
+			// display->key, display->visible);
+			break;
+		}
+		case RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION: { /* 57 */
+			unsigned* out = (unsigned*)data;
+			if (out) *out = 1;
+			break;
+		}
+		case RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE: { /* 58 */
+			const struct retro_disk_control_ext_callback* var =
+				(const struct retro_disk_control_ext_callback*)data;
+
+			if (var) {
+				memcpy(&disk_control_ext, var,
+					   sizeof(struct retro_disk_control_ext_callback));
+			}
+			break;
+		}
+		// TODO: RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION 59
+		// TODO: used by mgba, (but only during frameskip?)
+		// case RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK: { /* 62 */
+		// 	LOG_info("RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK\n");
+		// 	const struct retro_audio_buffer_status_callback *cb = (const struct
+		// retro_audio_buffer_status_callback *)data; 	if (cb) {
+		// LOG_info("has audo_buffer_status callback\n");
+		// core.audio_buffer_status = cb->callback; 	} else {
+		// LOG_info("no audo_buffer_status callback\n");
+		// 		core.audio_buffer_status = NULL;
+		// 	}
+		// 	break;
+		// }
+		// TODO: used by mgba, (but only during frameskip?)
+		// case RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY: { /* 63 */
+		// 	LOG_info("RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY\n");
+		//
+		// 	const unsigned *latency_ms = (const unsigned *)data;
+		// 	if (latency_ms) {
+		// 		unsigned frames = *latency_ms * core.fps / 1000;
+		// 		if (frames < 30)
+		// 			// audio_buffer_size_override = frames;
+		// 			LOG_info("audio_buffer_size_override = %i (unused?)\n",
+		// frames); 		else 			LOG_info("Audio buffer change out of
+		// range (%d), ignored\n", frames);
+		// 	}
+		// 	break;
+		// }
+
+		// TODO: RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
+		case RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE: { /* 65 */
+			// const struct retro_system_content_info_override* info = (const
+			// struct retro_system_content_info_override* )data; if (info)
+			// LOG_info("has overrides");
+			break;
+		}
+		// RETRO_ENVIRONMENT_GET_GAME_INFO_EXT 66
+		// TODO: RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK 69
+		// used by fceumm
+		// TODO: used by gambatte for L/R palette switching (seems like it needs
+		// to return true even if data is NULL to indicate support)
+		case RETRO_ENVIRONMENT_SET_VARIABLE: {
+			// puts("RETRO_ENVIRONMENT_SET_VARIABLE");
+			const struct retro_variable* var =
+				(const struct retro_variable*)data;
+			if (var && var->key) {
+				// printf("\t%s = %s\n", var->key, var->value);
+				OptionList_setOptionValue(&config.core, var->key, var->value);
+				break;
+			}
+
+			int* out = (int*)data;
+			if (out) *out = 1;
+
+			break;
+		}
+
+			// unused
+			// case RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK: {
+			// 	puts("RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK");
+			// fflush(stdout); 	break;
+			// }
+			// case RETRO_ENVIRONMENT_GET_THROTTLE_STATE: {
+			// 	puts("RETRO_ENVIRONMENT_GET_THROTTLE_STATE"); fflush(stdout);
+			// 	break;
+			// }
+			// case RETRO_ENVIRONMENT_GET_FASTFORWARDING: {
+			// 	puts("RETRO_ENVIRONMENT_GET_FASTFORWARDING"); fflush(stdout);
+			// 	break;
+			// };
+
+		default:
+			// LOG_debug("Unsupported environment cmd: %u\n", cmd);
+			return false;
 	}
 	return true;
 }
@@ -2159,8 +2248,8 @@ static void hdmimon(void) {
 	// handle HDMI change
 	static int had_hdmi = -1;
 	int has_hdmi = GetHDMI();
-	if (had_hdmi==-1) had_hdmi = has_hdmi;
-	if (has_hdmi!=had_hdmi) {
+	if (had_hdmi == -1) had_hdmi = has_hdmi;
+	if (has_hdmi != had_hdmi) {
 		had_hdmi = has_hdmi;
 
 		LOG_info("restarting after HDMI change...\n");
@@ -2183,83 +2272,89 @@ enum {
 	DIGIT_DOT,
 	DIGIT_PERCENT,
 	DIGIT_X,
-	DIGIT_OP, // (
-	DIGIT_CP, // )
+	DIGIT_OP,  // (
+	DIGIT_CP,  // )
 	DIGIT_COUNT,
 };
 #define DIGIT_SPACE DIGIT_COUNT
 static void MSG_init(void) {
-	digits = SDL_CreateRGBSurface(SDL_SWSURFACE,SCALE2(DIGIT_WIDTH*DIGIT_COUNT,DIGIT_HEIGHT),FIXED_DEPTH, 0,0,0,0);
+	digits = SDL_CreateRGBSurface(
+		SDL_SWSURFACE, SCALE2(DIGIT_WIDTH * DIGIT_COUNT, DIGIT_HEIGHT),
+		FIXED_DEPTH, 0, 0, 0, 0);
 	SDL_FillRect(digits, NULL, RGB_BLACK);
-	
+
 	SDL_Surface* digit;
-	char* chars[] = { "0","1","2","3","4","5","6","7","8","9","/",".","%","x","(",")", NULL };
+	char* chars[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8",
+					 "9", "/", ".", "%", "x", "(", ")", NULL};
 	char* c;
 	int i = 0;
 	while ((c = chars[i])) {
 		digit = TTF_RenderUTF8_Blended(font.tiny, c, COLOR_WHITE);
-		SDL_BlitSurface(digit, NULL, digits, &(SDL_Rect){ (i * SCALE1(DIGIT_WIDTH)) + (SCALE1(DIGIT_WIDTH) - digit->w)/2, (SCALE1(DIGIT_HEIGHT) - digit->h)/2});
+		SDL_BlitSurface(digit, NULL, digits,
+						&(SDL_Rect){(i * SCALE1(DIGIT_WIDTH)) +
+										(SCALE1(DIGIT_WIDTH) - digit->w) / 2,
+									(SCALE1(DIGIT_HEIGHT) - digit->h) / 2});
 		SDL_FreeSurface(digit);
 		i += 1;
 	}
 }
 static int MSG_blitChar(int n, int x, int y) {
-	if (n!=DIGIT_SPACE) SDL_BlitSurface(digits, &(SDL_Rect){n*SCALE1(DIGIT_WIDTH),0,SCALE2(DIGIT_WIDTH,DIGIT_HEIGHT)}, screen, &(SDL_Rect){x,y});
+	if (n != DIGIT_SPACE)
+		SDL_BlitSurface(digits,
+						&(SDL_Rect){n * SCALE1(DIGIT_WIDTH), 0,
+									SCALE2(DIGIT_WIDTH, DIGIT_HEIGHT)},
+						screen, &(SDL_Rect){x, y});
 	return x + SCALE1(DIGIT_WIDTH + DIGIT_TRACKING);
 }
 static int MSG_blitInt(int num, int x, int y) {
 	int i = num;
 	int n;
-	
+
 	if (i > 999) {
 		n = i / 1000;
 		i -= n * 1000;
-		x = MSG_blitChar(n,x,y);
+		x = MSG_blitChar(n, x, y);
 	}
 	if (i > 99) {
 		n = i / 100;
 		i -= n * 100;
-		x = MSG_blitChar(n,x,y);
-	}
-	else if (num>99) {
-		x = MSG_blitChar(0,x,y);
+		x = MSG_blitChar(n, x, y);
+	} else if (num > 99) {
+		x = MSG_blitChar(0, x, y);
 	}
 	if (i > 9) {
 		n = i / 10;
 		i -= n * 10;
-		x = MSG_blitChar(n,x,y);
+		x = MSG_blitChar(n, x, y);
+	} else if (num > 9) {
+		x = MSG_blitChar(0, x, y);
 	}
-	else if (num>9) {
-		x = MSG_blitChar(0,x,y);
-	}
-	
+
 	n = i;
-	x = MSG_blitChar(n,x,y);
-	
+	x = MSG_blitChar(n, x, y);
+
 	return x;
 }
 static int MSG_blitDouble(double num, int x, int y) {
 	int i = num;
-	int r = (num-i) * 10;
+	int r = (num - i) * 10;
 	int n;
-	
-	x = MSG_blitInt(i, x,y);
+
+	x = MSG_blitInt(i, x, y);
 
 	n = DIGIT_DOT;
-	x = MSG_blitChar(n,x,y);
-	
+	x = MSG_blitChar(n, x, y);
+
 	n = r;
-	x = MSG_blitChar(n,x,y);
+	x = MSG_blitChar(n, x, y);
 	return x;
 }
-static void MSG_quit(void) {
-	SDL_FreeSurface(digits);
-}
+static void MSG_quit(void) { SDL_FreeSurface(digits); }
 
 ///////////////////////////////
 
 static const char* bitmap_font[] = {
-	['0'] = 
+	['0'] =
 		" 111 "
 		"1   1"
 		"1   1"
@@ -2359,7 +2454,7 @@ static const char* bitmap_font[] = {
 		"    1"
 		"    1"
 		" 111 ",
-	['.'] = 
+	['.'] =
 		"     "
 		"     "
 		"     "
@@ -2369,7 +2464,7 @@ static const char* bitmap_font[] = {
 		"     "
 		" 11  "
 		" 11  ",
-	[','] = 
+	[','] =
 		"     "
 		"     "
 		"     "
@@ -2379,7 +2474,7 @@ static const char* bitmap_font[] = {
 		"  1  "
 		"  1  "
 		" 1   ",
-	[' '] = 
+	[' '] =
 		"     "
 		"     "
 		"     "
@@ -2389,7 +2484,7 @@ static const char* bitmap_font[] = {
 		"     "
 		"     "
 		"     ",
-	['('] = 
+	['('] =
 		"   1 "
 		"  1  "
 		" 1   "
@@ -2399,7 +2494,7 @@ static const char* bitmap_font[] = {
 		" 1   "
 		"  1  "
 		"   1 ",
-	[')'] = 
+	[')'] =
 		" 1   "
 		"  1  "
 		"   1 "
@@ -2409,7 +2504,7 @@ static const char* bitmap_font[] = {
 		"   1 "
 		"  1  "
 		" 1   ",
-	['/'] = 
+	['/'] =
 		"   1 "
 		"   1 "
 		"   1 "
@@ -2419,7 +2514,7 @@ static const char* bitmap_font[] = {
 		" 1   "
 		" 1   "
 		" 1   ",
-	['x'] = 
+	['x'] =
 		"     "
 		"     "
 		"1   1"
@@ -2429,7 +2524,7 @@ static const char* bitmap_font[] = {
 		" 1 1 "
 		"1   1"
 		"1   1",
-	['%'] = 
+	['%'] =
 		" 1   "
 		"1 1  "
 		"1 1 1"
@@ -2449,37 +2544,40 @@ static const char* bitmap_font[] = {
 		"     "
 		"     "
 		"     ",
-	};
-static void blitBitmapText(char* text, int ox, int oy, uint16_t* data, int stride, int width, int height) {
-	#define CHAR_WIDTH 5
-	#define CHAR_HEIGHT 9
-	#define LETTERSPACING 1
-	
+};
+static void blitBitmapText(char* text, int ox, int oy, uint16_t* data,
+						   int stride, int width, int height) {
+#define CHAR_WIDTH 5
+#define CHAR_HEIGHT 9
+#define LETTERSPACING 1
+
 	int len = strlen(text);
-	int w = ((CHAR_WIDTH+LETTERSPACING)*len)-1;
+	int w = ((CHAR_WIDTH + LETTERSPACING) * len) - 1;
 	int h = CHAR_HEIGHT;
-	
-	if (ox<0) ox = width-w+ox;
-	if (oy<0) oy = height-h+oy;
-	
+
+	if (ox < 0) ox = width - w + ox;
+	if (oy < 0) oy = height - h + oy;
+
 	data += oy * stride + ox;
-	uint16_t* row = data - stride; // TODO: this will crash and burn if ox,oy==0,0 but is fine as used currently :sweat_smile:
-	memset(row-1, 0, (w+2)*2);
-	for (int y=0; y<CHAR_HEIGHT; y++) {
+	uint16_t* row =
+		data - stride;	// TODO: this will crash and burn if ox,oy==0,0 but is
+						// fine as used currently :sweat_smile:
+	memset(row - 1, 0, (w + 2) * 2);
+	for (int y = 0; y < CHAR_HEIGHT; y++) {
 		row = data + y * stride;
-		memset(row-1, 0, (w+2)*2);
-		for (int i=0; i<len; i++) {
+		memset(row - 1, 0, (w + 2) * 2);
+		for (int i = 0; i < len; i++) {
 			const char* c = bitmap_font[text[i]];
-			for (int x=0; x<CHAR_WIDTH; x++) {
+			for (int x = 0; x < CHAR_WIDTH; x++) {
 				int j = y * CHAR_WIDTH + x;
-				if (c[j]=='1') *row = 0xffff;
+				if (c[j] == '1') *row = 0xffff;
 				row++;
 			}
 			row += LETTERSPACING;
 		}
 	}
 	row = data + CHAR_HEIGHT * stride;
-	memset(row-1, 0, (w+2)*2);
+	memset(row - 1, 0, (w + 2) * 2);
 }
 
 ///////////////////////////////
@@ -2493,10 +2591,10 @@ static double use_double = 0;
 static uint32_t sec_start = 0;
 
 #ifdef USES_SWSCALER
-	static int fit = 1;
+static int fit = 1;
 #else
-	static int fit = 0;
-#endif	
+static int fit = 0;
+#endif
 
 // buffer to convert xrgb8888 to rgb565
 static void* buffer = NULL;
@@ -2510,45 +2608,47 @@ static void buffer_realloc(int w, int h, int p) {
 	buffer = malloc((w * FIXED_BPP) * h);
 	// LOG_info("buffer_realloc(%i,%i,%i)\n", w,h,p);
 }
-static void buffer_downsample(const void *data, unsigned width, unsigned height, size_t pitch) {
+static void buffer_downsample(const void* data, unsigned width, unsigned height,
+							  size_t pitch) {
 	// from picoarch! https://git.crowdedwood.com/picoarch/tree/video.c#n51
-	const uint32_t *input = data;
-	uint16_t *output = buffer;
+	const uint32_t* input = data;
+	uint16_t* output = buffer;
 	size_t extra = pitch / sizeof(uint32_t) - width;
 
 	for (int y = 0; y < height; y++) {
 		for (int x = 0; x < width; x++) {
-			*output =  (*input & 0xF80000) >> 8;
+			*output = (*input & 0xF80000) >> 8;
 			*output |= (*input & 0xFC00) >> 5;
 			*output |= (*input & 0xF8) >> 3;
 			input++;
 			output++;
 		}
 
-		input += extra; // TODO: commenting this out fixes geolith when cropped, it appears to be lying about the pitch...
+		input += extra;	 // TODO: commenting this out fixes geolith when
+						 // cropped, it appears to be lying about the pitch...
 	}
 }
 
 static void selectScaler(int src_w, int src_h, int src_p) {
 	LOG_info("selectScaler\n");
-	
-	if (downsample) buffer_realloc(src_w,src_h,src_p);
-	
-	int src_x,src_y,dst_x,dst_y,dst_w,dst_h,dst_p,scale;
+
+	if (downsample) buffer_realloc(src_w, src_h, src_p);
+
+	int src_x, src_y, dst_x, dst_y, dst_w, dst_h, dst_p, scale;
 	double aspect;
-	
+
 	int aspect_w = src_w;
 	int aspect_h = CEIL_DIV(aspect_w, core.aspect_ratio);
-	
+
 	// TODO: make sure this doesn't break fit==1 devices
-	if (aspect_h<src_h) {
+	if (aspect_h < src_h) {
 		aspect_h = src_h;
 		aspect_w = aspect_h * core.aspect_ratio;
 		aspect_w += aspect_w % 2;
 	}
 
 	char scaler_name[16];
-	
+
 	src_x = 0;
 	src_y = 0;
 	dst_x = 0;
@@ -2557,36 +2657,42 @@ static void selectScaler(int src_w, int src_h, int src_p) {
 	// unmodified by crop
 	renderer.true_w = src_w;
 	renderer.true_h = src_h;
-	
+
 	// TODO: this is saving non-rgb30 devices from themselves...or rather, me
 	int scaling = screen_scaling;
-	if (scaling==SCALE_CROPPED && DEVICE_WIDTH==HDMI_WIDTH) {
+	if (scaling == SCALE_CROPPED && DEVICE_WIDTH == HDMI_WIDTH) {
 		scaling = SCALE_NATIVE;
 	}
-	
-	if (scaling==SCALE_NATIVE || scaling==SCALE_CROPPED) {
+
+	if (scaling == SCALE_NATIVE || scaling == SCALE_CROPPED) {
 		// this is the same whether fit or oversized
-		scale = MIN(DEVICE_WIDTH/src_w, DEVICE_HEIGHT/src_h);
+		scale = MIN(DEVICE_WIDTH / src_w, DEVICE_HEIGHT / src_h);
 		if (!scale) {
 			sprintf(scaler_name, "forced crop");
 			dst_w = DEVICE_WIDTH;
 			dst_h = DEVICE_HEIGHT;
 			dst_p = DEVICE_PITCH;
-			
-			int ox = (DEVICE_WIDTH  - src_w) / 2; // may be negative
-			int oy = (DEVICE_HEIGHT - src_h) / 2; // may be negative
-			
-			if (ox<0) src_x = -ox;
-			else dst_x = ox;
-			
-			if (oy<0) src_y = -oy;
-			else dst_y = oy;
+
+			int ox = (DEVICE_WIDTH - src_w) / 2;   // may be negative
+			int oy = (DEVICE_HEIGHT - src_h) / 2;  // may be negative
+
+			if (ox < 0)
+				src_x = -ox;
+			else
+				dst_x = ox;
+
+			if (oy < 0)
+				src_y = -oy;
+			else
+				dst_y = oy;
 		}
 		// TODO: this is all kinds of messed up
-		// TODO: is this blowing up because the smart has to rotate before scaling?
-		// TODO: or is it just that I'm trying to cram 4 logical rects into 2 rect arguments
+		// TODO: is this blowing up because the smart has to rotate before
+		// scaling?
+		// TODO: or is it just that I'm trying to cram 4 logical rects into 2
+		// rect arguments
 		// TODO: eg. src.size + src.clip + dst.size + dst.clip
-		else if (scaling==SCALE_CROPPED) {
+		else if (scaling == SCALE_CROPPED) {
 			int scale_x = CEIL_DIV(DEVICE_WIDTH, src_w);
 			int scale_y = CEIL_DIV(DEVICE_HEIGHT, src_h);
 			scale = MIN(scale_x, scale_y);
@@ -2599,100 +2705,97 @@ static void selectScaler(int src_w, int src_h, int src_p) {
 			int scaled_w = src_w * scale;
 			int scaled_h = src_h * scale;
 
-			int ox = (DEVICE_WIDTH  - scaled_w) / 2; // may be negative
-			int oy = (DEVICE_HEIGHT - scaled_h) / 2; // may be negative
+			int ox = (DEVICE_WIDTH - scaled_w) / 2;	  // may be negative
+			int oy = (DEVICE_HEIGHT - scaled_h) / 2;  // may be negative
 
-			if (ox<0) {
+			if (ox < 0) {
 				src_x = -ox / scale;
 				src_w -= src_x * 2;
-			}
-			else {
+			} else {
 				dst_x = ox;
 				// dst_w -= ox * 2;
 			}
 
-			if (oy<0) {
+			if (oy < 0) {
 				src_y = -oy / scale;
 				src_h -= src_y * 2;
-			}
-			else {
+			} else {
 				dst_y = oy;
 				// dst_h -= oy * 2;
 			}
-		}
-		else {
+		} else {
 			sprintf(scaler_name, "integer");
 			int scaled_w = src_w * scale;
 			int scaled_h = src_h * scale;
 			dst_w = DEVICE_WIDTH;
 			dst_h = DEVICE_HEIGHT;
 			dst_p = DEVICE_PITCH;
-			dst_x = (DEVICE_WIDTH  - scaled_w) / 2; // should always be positive
-			dst_y = (DEVICE_HEIGHT - scaled_h) / 2; // should always be positive
+			dst_x = (DEVICE_WIDTH - scaled_w) / 2;	// should always be positive
+			dst_y =
+				(DEVICE_HEIGHT - scaled_h) / 2;	 // should always be positive
 		}
-	}
-	else if (fit) {
+	} else if (fit) {
 		// these both will use a generic nn scaler
-		if (scaling==SCALE_FULLSCREEN) {
+		if (scaling == SCALE_FULLSCREEN) {
 			sprintf(scaler_name, "full fit");
 			dst_w = DEVICE_WIDTH;
 			dst_h = DEVICE_HEIGHT;
 			dst_p = DEVICE_PITCH;
-			scale = -1; // nearest neighbor
-		}
-		else {
-			double scale_f = MIN(((double)DEVICE_WIDTH)/aspect_w, ((double)DEVICE_HEIGHT)/aspect_h);
+			scale = -1;	 // nearest neighbor
+		} else {
+			double scale_f = MIN(((double)DEVICE_WIDTH) / aspect_w,
+								 ((double)DEVICE_HEIGHT) / aspect_h);
 			LOG_info("scale_f:%f\n", scale_f);
-			
+
 			sprintf(scaler_name, "aspect fit");
 			dst_w = aspect_w * scale_f;
 			dst_h = aspect_h * scale_f;
 			dst_p = DEVICE_PITCH;
-			dst_x = (DEVICE_WIDTH  - dst_w) / 2;
+			dst_x = (DEVICE_WIDTH - dst_w) / 2;
 			dst_y = (DEVICE_HEIGHT - dst_h) / 2;
-			scale = (scale_f==1.0 && dst_w==src_w && dst_h==src_h) ? 1 : -1;
+			scale =
+				(scale_f == 1.0 && dst_w == src_w && dst_h == src_h) ? 1 : -1;
 		}
-	}
-	else {
+	} else {
 		int scale_x = CEIL_DIV(DEVICE_WIDTH, src_w);
-		int scale_y = CEIL_DIV(DEVICE_HEIGHT,src_h);
-		
-		// odd resolutions (eg. PS1 Rayman: 320x239) is throwing this off, need to snap to eights
-		int r = (DEVICE_HEIGHT-src_h)%8;
-		if (r && r<8) scale_y -= 1;
-		
+		int scale_y = CEIL_DIV(DEVICE_HEIGHT, src_h);
+
+		// odd resolutions (eg. PS1 Rayman: 320x239) is throwing this off, need
+		// to snap to eights
+		int r = (DEVICE_HEIGHT - src_h) % 8;
+		if (r && r < 8) scale_y -= 1;
+
 		scale = MAX(scale_x, scale_y);
 		// if (scale>4) scale = 4;
 		// if (scale>2) scale = 4; // TODO: restore, requires sanity checking
-		
+
 		int scaled_w = src_w * scale;
 		int scaled_h = src_h * scale;
-		
-		if (scaling==SCALE_FULLSCREEN) {
+
+		if (scaling == SCALE_FULLSCREEN) {
 			sprintf(scaler_name, "full%i", scale);
 			// type = 'full (oversized)';
 			dst_w = scaled_w;
 			dst_h = scaled_h;
 			dst_p = dst_w * FIXED_BPP;
-		}
-		else {
+		} else {
 			double src_aspect_ratio = ((double)src_w) / src_h;
 			// double core_aspect_ratio
 			double fixed_aspect_ratio = ((double)DEVICE_WIDTH) / DEVICE_HEIGHT;
 			int core_aspect = core.aspect_ratio * 1000;
 			int fixed_aspect = fixed_aspect_ratio * 1000;
-			
+
 			// still having trouble with FC's 1.306 (13/10? wtf) on 4:3 devices
-			// specifically I think it has trouble when src, core, and fixed 
+			// specifically I think it has trouble when src, core, and fixed
 			// ratios don't match
-			
-			// it handles src and core matching but fixed not, eg. GB and GBA 
+
+			// it handles src and core matching but fixed not, eg. GB and GBA
 			// or core and fixed matching but not src, eg. odd PS resolutions
-			
+
 			// we need to transform the src size to core aspect
 			// then to fixed aspect
-						
-			if (core_aspect>fixed_aspect) {
+
+			if (core_aspect > fixed_aspect) {
 				sprintf(scaler_name, "aspect%iL", scale);
 				// letterbox
 				// dst_w = scaled_w;
@@ -2704,8 +2807,7 @@ static void selectScaler(int src_w, int src_h, int src_p) {
 				dst_h = scaled_h / aspect_hr;
 
 				dst_y = (dst_h - scaled_h) / 2;
-			}
-			else if (core_aspect<fixed_aspect) {
+			} else if (core_aspect < fixed_aspect) {
 				sprintf(scaler_name, "aspect%iP", scale);
 				// pillarbox
 				// dst_w = scaled_h * fixed_aspect_ratio;
@@ -2715,11 +2817,10 @@ static void selectScaler(int src_w, int src_h, int src_p) {
 				double aspect_wr = ((double)aspect_w) / DEVICE_WIDTH;
 				dst_w = scaled_w / aspect_wr;
 				dst_h = scaled_h;
-				
-				dst_w = (dst_w/8)*8;
+
+				dst_w = (dst_w / 8) * 8;
 				dst_x = (dst_w - scaled_w) / 2;
-			}
-			else {
+			} else {
 				sprintf(scaler_name, "aspect%iM", scale);
 				// perfect match
 				dst_w = scaled_w;
@@ -2728,11 +2829,11 @@ static void selectScaler(int src_w, int src_h, int src_p) {
 			dst_p = dst_w * FIXED_BPP;
 		}
 	}
-	
+
 	// TODO: need to sanity check scale and demands on the buffer
-	
+
 	// LOG_info("aspect: %ix%i (%f)\n", aspect_w,aspect_h,core.aspect_ratio);
-	
+
 	renderer.src_x = src_x;
 	renderer.src_y = src_y;
 	renderer.src_w = src_w;
@@ -2744,14 +2845,18 @@ static void selectScaler(int src_w, int src_h, int src_p) {
 	renderer.dst_h = dst_h;
 	renderer.dst_p = dst_p;
 	renderer.scale = scale;
-	renderer.aspect = (scaling==SCALE_NATIVE||scaling==SCALE_CROPPED)?0:(scaling==SCALE_FULLSCREEN?-1:core.aspect_ratio);
+	renderer.aspect =
+		(scaling == SCALE_NATIVE || scaling == SCALE_CROPPED)
+			? 0
+			: (scaling == SCALE_FULLSCREEN ? -1 : core.aspect_ratio);
 	LOG_info("aspect: %f\n", renderer.aspect);
 	renderer.blit = GFX_getScaler(&renderer);
-		
-	// LOG_info("coreAR:%0.3f fixedAR:%0.3f srcAR: %0.3f\nname:%s\nfit:%i scale:%i\nsrc_x:%i src_y:%i src_w:%i src_h:%i src_p:%i\ndst_x:%i dst_y:%i dst_w:%i dst_h:%i dst_p:%i\naspect_w:%i aspect_h:%i\n",
-	// 	core.aspect_ratio, ((double)DEVICE_WIDTH) / DEVICE_HEIGHT, ((double)src_w) / src_h,
-	// 	scaler_name,
-	// 	fit,scale,
+
+	// LOG_info("coreAR:%0.3f fixedAR:%0.3f srcAR: %0.3f\nname:%s\nfit:%i
+	// scale:%i\nsrc_x:%i src_y:%i src_w:%i src_h:%i src_p:%i\ndst_x:%i dst_y:%i
+	// dst_w:%i dst_h:%i dst_p:%i\naspect_w:%i aspect_h:%i\n",
+	// 	core.aspect_ratio, ((double)DEVICE_WIDTH) / DEVICE_HEIGHT,
+	// ((double)src_w) / src_h, 	scaler_name, 	fit,scale,
 	// 	src_x,src_y,src_w,src_h,src_p,
 	// 	dst_x,dst_y,dst_w,dst_h,dst_p,
 	// 	aspect_w,aspect_h
@@ -2761,28 +2866,30 @@ static void selectScaler(int src_w, int src_h, int src_p) {
 		dst_w = DEVICE_WIDTH;
 		dst_h = DEVICE_HEIGHT;
 	}
-	
+
 	// if (screen->w!=dst_w || screen->h!=dst_w || screen->pitch!=dst_p) {
-		screen = GFX_resize(dst_w,dst_h,dst_p);
+	screen = GFX_resize(dst_w, dst_h, dst_p);
 	// }
 }
-static void video_refresh_callback_main(const void *data, unsigned width, unsigned height, size_t pitch) {
+static void video_refresh_callback_main(const void* data, unsigned width,
+										unsigned height, size_t pitch) {
 	// return;
-	
+
 	Special_render();
-	
+
 	// static int tmp_frameskip = 0;
 	// if ((tmp_frameskip++)%2) return;
-	
+
 	static uint32_t last_flip_time = 0;
-	
-	// 10 seems to be the sweet spot that allows 2x in NES and SNES and 8x in GB at 60fps
-	// 14 will let GB hit 10x but NES and SNES will drop to 1.5x at 30fps (not sure why)
-	// but 10 hurts PS...
-	// TODO: 10 was based on rg35xx, probably different results on other supported platforms
-	if (fast_forward && SDL_GetTicks()-last_flip_time<10) return;
-	
-	// FFVII menus 
+
+	// 10 seems to be the sweet spot that allows 2x in NES and SNES and 8x in GB
+	// at 60fps 14 will let GB hit 10x but NES and SNES will drop to 1.5x at
+	// 30fps (not sure why) but 10 hurts PS...
+	// TODO: 10 was based on rg35xx, probably different results on other
+	// supported platforms
+	if (fast_forward && SDL_GetTicks() - last_flip_time < 10) return;
+
+	// FFVII menus
 	// 16: 30/200
 	// 15: 30/180
 	// 14: 45/180
@@ -2791,94 +2898,108 @@ static void video_refresh_callback_main(const void *data, unsigned width, unsign
 	//  8: 60/210 (with optimize text off)
 	// you can squeeze more out of every console by turning prevent tearing off
 	// eg. PS@10 60/240
-	
+
 	if (!data) return;
 
 	fps_ticks += 1;
-	
-	if (downsample) pitch /= 2; // everything expects 16 but we're downsampling from 32
-	
+
+	if (downsample)
+		pitch /= 2;	 // everything expects 16 but we're downsampling from 32
+
 	// if source has changed size (or forced by dst_p==0)
 	// eg. true src + cropped src + fixed dst + cropped dst
-	if (renderer.dst_p==0 || width!=renderer.true_w || height!=renderer.true_h) {
+	if (renderer.dst_p == 0 || width != renderer.true_w ||
+		height != renderer.true_h) {
 		selectScaler(width, height, pitch);
 		GFX_clearAll();
 	}
-	
+
 	// debug
 	if (show_debug) {
 		int x = 2 + renderer.src_x;
 		int y = 2 + renderer.src_y;
 		char debug_text[128];
 		int scale = renderer.scale;
-		if (scale==-1) scale = 1; // nearest neighbor flag
-		
-		sprintf(debug_text, "%ix%i %ix", renderer.src_w,renderer.src_h, scale);
-		blitBitmapText(debug_text,x,y,(uint16_t*)data,pitch/2, width,height);
+		if (scale == -1) scale = 1;	 // nearest neighbor flag
 
-		sprintf(debug_text, "%.03f/%i//%.03f", currentratio, currentbufferfree,currentfps);
-		blitBitmapText(debug_text,x,y*2.2,(uint16_t*)data,pitch/2, width,height);
+		sprintf(debug_text, "%ix%i %ix", renderer.src_w, renderer.src_h, scale);
+		blitBitmapText(debug_text, x, y, (uint16_t*)data, pitch / 2, width,
+					   height);
 
-		sprintf(debug_text, "%i,%i %ix%i", renderer.dst_x,renderer.dst_y, renderer.src_w*scale,renderer.src_h*scale);
-		blitBitmapText(debug_text,-x,y,(uint16_t*)data,pitch/2, width,height);
-	
-		sprintf(debug_text, "%.01f/%.01f %i%%", fps_double, cpu_double, (int)use_double);
-		blitBitmapText(debug_text,x,-y,(uint16_t*)data,pitch/2, width,height);
+		sprintf(debug_text, "%.03f/%i//%.03f", currentratio, currentbufferfree,
+				currentfps);
+		blitBitmapText(debug_text, x, y + 20, (uint16_t*)data, pitch / 2, width,
+					   height);
 
-	
-	
-		sprintf(debug_text, "%ix%i", renderer.dst_w,renderer.dst_h);
-		blitBitmapText(debug_text,-x,-y,(uint16_t*)data,pitch/2, width,height);
+		sprintf(debug_text, "%i,%i %ix%i", renderer.dst_x, renderer.dst_y,
+				renderer.src_w * scale, renderer.src_h * scale);
+		blitBitmapText(debug_text, -x, y, (uint16_t*)data, pitch / 2, width,
+					   height);
+
+		sprintf(debug_text, "%.01f/%.01f %i%%", fps_double, cpu_double,
+				(int)use_double);
+		blitBitmapText(debug_text, x, -y, (uint16_t*)data, pitch / 2, width,
+					   height);
+
+		sprintf(debug_text, "%ix%i", renderer.dst_w, renderer.dst_h);
+		blitBitmapText(debug_text, -x, -y, (uint16_t*)data, pitch / 2, width,
+					   height);
 	}
-	
+
 	if (downsample) {
-		buffer_downsample(data,width,height,pitch*2);
+		buffer_downsample(data, width, height, pitch * 2);
 		renderer.src = buffer;
-	}
-	else {
+	} else {
 		renderer.src = (void*)data;
 	}
 	renderer.dst = screen->pixels;
-	// LOG_info("video_refresh_callback: %ix%i@%i %ix%i@%i\n",width,height,pitch,screen->w,screen->h,screen->pitch);
-	
+	// LOG_info("video_refresh_callback: %ix%i@%i
+	// %ix%i@%i\n",width,height,pitch,screen->w,screen->h,screen->pitch);
+
 	GFX_blitRenderer(&renderer);
-	
+
 	if (!thread_video) GFX_flip(screen);
 	last_flip_time = SDL_GetTicks();
 }
-static void video_refresh_callback(const void *data, unsigned width, unsigned height, size_t pitch) {
+static void video_refresh_callback(const void* data, unsigned width,
+								   unsigned height, size_t pitch) {
 	if (!data) return;
-	
+
 	if (thread_video) {
 		pthread_mutex_lock(&core_mx);
-		
-		if (backbuffer && (backbuffer->w!=width || backbuffer->h!=height || backbuffer->pitch!=pitch)) {
+
+		if (backbuffer && (backbuffer->w != width || backbuffer->h != height ||
+						   backbuffer->pitch != pitch)) {
 			free(backbuffer->pixels);
 			SDL_FreeSurface(backbuffer);
 			backbuffer = NULL;
 		}
 		if (!backbuffer) {
-			uint16_t* pixels = malloc(height*pitch);
-			// backbuffer = SDL_CreateRGBSurface(0,width,height,FIXED_DEPTH,RGBA_MASK_565);
-			backbuffer = SDL_CreateRGBSurfaceFrom(pixels, width, height, FIXED_DEPTH, pitch, RGBA_MASK_565);
+			uint16_t* pixels = malloc(height * pitch);
+			// backbuffer =
+			// SDL_CreateRGBSurface(0,width,height,FIXED_DEPTH,RGBA_MASK_565);
+			backbuffer = SDL_CreateRGBSurfaceFrom(
+				pixels, width, height, FIXED_DEPTH, pitch, RGBA_MASK_565);
 		}
-		
-		memcpy(backbuffer->pixels, data, backbuffer->h*backbuffer->pitch);
-		
+
+		memcpy(backbuffer->pixels, data, backbuffer->h * backbuffer->pitch);
+
 		pthread_cond_signal(&core_rq);
 		pthread_mutex_unlock(&core_mx);
-	}
-	else video_refresh_callback_main(data,width,height,pitch);
+	} else
+		video_refresh_callback_main(data, width, height, pitch);
 }
 ///////////////////////////////
 
 // NOTE: sound must be disabled for fast forward to work...
 static void audio_sample_callback(int16_t left, int16_t right) {
-	if (!fast_forward) SND_batchSamples(&(const SND_Frame){left,right}, 1);
+	if (!fast_forward) SND_batchSamples(&(const SND_Frame){left, right}, 1);
 }
-static size_t audio_sample_batch_callback(const int16_t *data, size_t frames) { 
-	if (!fast_forward) return SND_batchSamples((const SND_Frame*)data, frames);
-	else return frames;
+static size_t audio_sample_batch_callback(const int16_t* data, size_t frames) {
+	if (!fast_forward)
+		return SND_batchSamples((const SND_Frame*)data, frames);
+	else
+		return frames;
 	// return frames;
 };
 
@@ -2892,14 +3013,15 @@ void Core_getName(char* in_name, char* out_name) {
 void Core_open(const char* core_path, const char* tag_name) {
 	LOG_info("Core_open\n");
 	core.handle = dlopen(core_path, RTLD_LAZY);
-	
+
 	if (!core.handle) LOG_error("%s\n", dlerror());
-	
+
 	core.init = dlsym(core.handle, "retro_init");
 	core.deinit = dlsym(core.handle, "retro_deinit");
 	core.get_system_info = dlsym(core.handle, "retro_get_system_info");
 	core.get_system_av_info = dlsym(core.handle, "retro_get_system_av_info");
-	core.set_controller_port_device = dlsym(core.handle, "retro_set_controller_port_device");
+	core.set_controller_port_device =
+		dlsym(core.handle, "retro_set_controller_port_device");
 	core.reset = dlsym(core.handle, "retro_reset");
 	core.run = dlsym(core.handle, "retro_run");
 	core.serialize_size = dlsym(core.handle, "retro_serialize_size");
@@ -2911,40 +3033,49 @@ void Core_open(const char* core_path, const char* tag_name) {
 	core.get_region = dlsym(core.handle, "retro_get_region");
 	core.get_memory_data = dlsym(core.handle, "retro_get_memory_data");
 	core.get_memory_size = dlsym(core.handle, "retro_get_memory_size");
-	
+
 	void (*set_environment_callback)(retro_environment_t);
 	void (*set_video_refresh_callback)(retro_video_refresh_t);
 	void (*set_audio_sample_callback)(retro_audio_sample_t);
 	void (*set_audio_sample_batch_callback)(retro_audio_sample_batch_t);
 	void (*set_input_poll_callback)(retro_input_poll_t);
 	void (*set_input_state_callback)(retro_input_state_t);
-	
+
 	set_environment_callback = dlsym(core.handle, "retro_set_environment");
 	set_video_refresh_callback = dlsym(core.handle, "retro_set_video_refresh");
 	set_audio_sample_callback = dlsym(core.handle, "retro_set_audio_sample");
-	set_audio_sample_batch_callback = dlsym(core.handle, "retro_set_audio_sample_batch");
+	set_audio_sample_batch_callback =
+		dlsym(core.handle, "retro_set_audio_sample_batch");
 	set_input_poll_callback = dlsym(core.handle, "retro_set_input_poll");
 	set_input_state_callback = dlsym(core.handle, "retro_set_input_state");
-	
+
 	struct retro_system_info info = {};
 	core.get_system_info(&info);
-	
+
 	Core_getName((char*)core_path, (char*)core.name);
-	sprintf((char*)core.version, "%s (%s)", info.library_name, info.library_version);
+	sprintf((char*)core.version, "%s (%s)", info.library_name,
+			info.library_version);
 	strcpy((char*)core.tag, tag_name);
 	strcpy((char*)core.extensions, info.valid_extensions);
-	
+
 	core.need_fullpath = info.need_fullpath;
-	
-	LOG_info("core: %s version: %s tag: %s (valid_extensions: %s need_fullpath: %i)\n", core.name, core.version, core.tag, info.valid_extensions, info.need_fullpath);
-	
-	sprintf((char*)core.config_dir, USERDATA_PATH "/%s-%s", core.tag, core.name);
-	sprintf((char*)core.states_dir, SHARED_USERDATA_PATH "/%s-%s", core.tag, core.name);
+
+	LOG_info(
+		"core: %s version: %s tag: %s (valid_extensions: %s need_fullpath: "
+		"%i)\n",
+		core.name, core.version, core.tag, info.valid_extensions,
+		info.need_fullpath);
+
+	sprintf((char*)core.config_dir, USERDATA_PATH "/%s-%s", core.tag,
+			core.name);
+	sprintf((char*)core.states_dir, SHARED_USERDATA_PATH "/%s-%s", core.tag,
+			core.name);
 	sprintf((char*)core.saves_dir, SDCARD_PATH "/Saves/%s", core.tag);
 	sprintf((char*)core.bios_dir, SDCARD_PATH "/Bios/%s", core.tag);
-	
+
 	char cmd[512];
-	sprintf(cmd, "mkdir -p \"%s\"; mkdir -p \"%s\"", core.config_dir, core.states_dir);
+	sprintf(cmd, "mkdir -p \"%s\"; mkdir -p \"%s\"", core.config_dir,
+			core.states_dir);
 	system(cmd);
 
 	set_environment_callback(environment_callback);
@@ -2962,35 +3093,36 @@ void Core_init(void) {
 void Core_load(void) {
 	LOG_info("Core_load\n");
 	struct retro_game_info game_info;
-	game_info.path = game.tmp_path[0]?game.tmp_path:game.path;
+	game_info.path = game.tmp_path[0] ? game.tmp_path : game.path;
 	game_info.data = game.data;
 	game_info.size = game.size;
 	LOG_info("game path: %s (%i)\n", game_info.path, game.size);
-	
+
 	core.load_game(&game_info);
-	
+
 	SRAM_read();
 	RTC_read();
-	
+
 	// NOTE: must be called after core.load_game!
 	struct retro_system_av_info av_info = {};
 	core.get_system_av_info(&av_info);
-	core.set_controller_port_device(0, RETRO_DEVICE_JOYPAD); // set a default, may update after loading configs
+	core.set_controller_port_device(
+		0, RETRO_DEVICE_JOYPAD);  // set a default, may update after loading
+								  // configs
 
 	core.fps = av_info.timing.fps;
 	core.sample_rate = av_info.timing.sample_rate;
 	double a = av_info.geometry.aspect_ratio;
-	if (a<=0) a = (double)av_info.geometry.base_width / av_info.geometry.base_height;
+	if (a <= 0)
+		a = (double)av_info.geometry.base_width / av_info.geometry.base_height;
 	core.aspect_ratio = a;
-	
-	LOG_info("aspect_ratio: %f (%ix%i) fps: %f\n", a, av_info.geometry.base_width,av_info.geometry.base_height, core.fps);
+
+	LOG_info("aspect_ratio: %f (%ix%i) fps: %f\n", a,
+			 av_info.geometry.base_width, av_info.geometry.base_height,
+			 core.fps);
 }
-void Core_reset(void) {
-	core.reset();
-}
-void Core_unload(void) {
-	SND_quit();
-}
+void Core_reset(void) { core.reset(); }
+void Core_unload(void) { SND_quit(); }
 void Core_quit(void) {
 	if (core.initialized) {
 		SRAM_write();
@@ -3018,13 +3150,13 @@ enum {
 };
 
 enum {
-	STATUS_CONT =  0,
-	STATUS_SAVE =  1,
+	STATUS_CONT = 0,
+	STATUS_SAVE = 1,
 	STATUS_LOAD = 11,
 	STATUS_OPTS = 23,
 	STATUS_DISC = 24,
 	STATUS_QUIT = 30,
-	STATUS_RESET= 31,
+	STATUS_RESET = 31,
 };
 
 // TODO: I don't love how overloaded this has become
@@ -3032,7 +3164,7 @@ static struct {
 	SDL_Surface* bitmap;
 	SDL_Surface* overlay;
 	char* items[MENU_ITEM_COUNT];
-	char* disc_paths[9]; // up to 9 paths, Arc the Lad Collection is 7 discs
+	char* disc_paths[9];  // up to 9 paths, Arc the Lad Collection is 7 discs
 	char minui_dir[256];
 	char slot_path[256];
 	char base_path[256];
@@ -3043,56 +3175,56 @@ static struct {
 	int slot;
 	int save_exists;
 	int preview_exists;
-} menu = {
-	.bitmap = NULL,
-	.disc = -1,
-	.total_discs = 0,
-	.save_exists = 0,
-	.preview_exists = 0,
-	
-	.items = {
-		[ITEM_CONT] = "Continue",
-		[ITEM_SAVE] = "Save",
-		[ITEM_LOAD] = "Load",
-		[ITEM_OPTS] = "Options",
-		[ITEM_QUIT] = "Quit",
-	}
-};
+} menu = {.bitmap = NULL,
+		  .disc = -1,
+		  .total_discs = 0,
+		  .save_exists = 0,
+		  .preview_exists = 0,
+
+		  .items = {
+			  [ITEM_CONT] = "Continue",
+			  [ITEM_SAVE] = "Save",
+			  [ITEM_LOAD] = "Load",
+			  [ITEM_OPTS] = "Options",
+			  [ITEM_QUIT] = "Quit",
+		  }};
 
 void Menu_init(void) {
-	menu.overlay = SDL_CreateRGBSurface(SDL_SWSURFACE,DEVICE_WIDTH,DEVICE_HEIGHT,FIXED_DEPTH,RGBA_MASK_AUTO);
+	menu.overlay =
+		SDL_CreateRGBSurface(SDL_SWSURFACE, DEVICE_WIDTH, DEVICE_HEIGHT,
+							 FIXED_DEPTH, RGBA_MASK_AUTO);
 	SDLX_SetAlpha(menu.overlay, SDL_SRCALPHA, 0x80);
 	SDL_FillRect(menu.overlay, NULL, 0);
-	
+
 	char emu_name[256];
 	getEmuName(game.path, emu_name);
 	sprintf(menu.minui_dir, SHARED_USERDATA_PATH "/.minui/%s", emu_name);
 	mkdir(menu.minui_dir, 0755);
 
 	sprintf(menu.slot_path, "%s/%s.txt", menu.minui_dir, game.name);
-	
+
 	if (simple_mode) menu.items[ITEM_OPTS] = "Reset";
-	
+
 	if (game.m3u_path[0]) {
 		char* tmp;
 		strcpy(menu.base_path, game.m3u_path);
 		tmp = strrchr(menu.base_path, '/') + 1;
 		tmp[0] = '\0';
-		
-		//read m3u file
+
+		// read m3u file
 		FILE* file = fopen(game.m3u_path, "r");
 		if (file) {
 			char line[256];
-			while (fgets(line,256,file)!=NULL) {
+			while (fgets(line, 256, file) != NULL) {
 				normalizeNewline(line);
 				trimTrailingNewlines(line);
-				if (strlen(line)==0) continue; // skip empty lines
-		
+				if (strlen(line) == 0) continue;  // skip empty lines
+
 				char disc_path[256];
 				strcpy(disc_path, menu.base_path);
 				tmp = disc_path + strlen(disc_path);
 				strcpy(tmp, line);
-				
+
 				// found a valid disc path
 				if (exists(disc_path)) {
 					menu.disc_paths[menu.total_discs] = strdup(disc_path);
@@ -3107,9 +3239,7 @@ void Menu_init(void) {
 		}
 	}
 }
-void Menu_quit(void) {
-	SDL_FreeSurface(menu.overlay);
-}
+void Menu_quit(void) { SDL_FreeSurface(menu.overlay); }
 void Menu_beforeSleep(void) {
 	// LOG_info("beforeSleep\n");
 	SRAM_write();
@@ -3136,8 +3266,8 @@ typedef struct MenuItem {
 	char* name;
 	char* desc;
 	char** values;
-	char* key; // optional, used by options
-	int id; // optional, used by bindings
+	char* key;	// optional, used by options
+	int id;		// optional, used by bindings
 	int value;
 	MenuList* submenu;
 	MenuList_callback_t on_confirm;
@@ -3145,14 +3275,14 @@ typedef struct MenuItem {
 } MenuItem;
 
 enum {
-	MENU_LIST, // eg. save and main menu
-	MENU_VAR, // eg. frontend
-	MENU_FIXED, // eg. emulator
-	MENU_INPUT, // eg. renders like but MENU_VAR but handles input differently
+	MENU_LIST,	 // eg. save and main menu
+	MENU_VAR,	 // eg. frontend
+	MENU_FIXED,	 // eg. emulator
+	MENU_INPUT,	 // eg. renders like but MENU_VAR but handles input differently
 };
 typedef struct MenuList {
 	int type;
-	int max_width; // cached on first draw
+	int max_width;	// cached on first draw
 	char* desc;
 	MenuItem* items;
 	MenuList_callback_t on_confirm;
@@ -3167,28 +3297,32 @@ static int Menu_message(char* message, char** pairs) {
 		PAD_poll();
 
 		if (PAD_justPressed(BTN_A) || PAD_justPressed(BTN_B)) break;
-		
+
 		PWR_update(&dirty, NULL, Menu_beforeSleep, Menu_afterSleep);
-		
+
 		if (dirty) {
 			GFX_clear(screen);
-			GFX_blitMessage(font.medium, message, screen, &(SDL_Rect){0,SCALE1(PADDING),screen->w,screen->h-SCALE1(PILL_SIZE+PADDING)});
+			GFX_blitMessage(
+				font.medium, message, screen,
+				&(SDL_Rect){0, SCALE1(PADDING), screen->w,
+							screen->h - SCALE1(PILL_SIZE + PADDING)});
 			GFX_blitButtonGroup(pairs, 0, screen, 1);
 			GFX_flip(screen);
 			dirty = 0;
-		}
-		else GFX_sync();
-		
+		} else
+			GFX_sync();
+
 		hdmimon();
 	}
 	GFX_setMode(MODE_MENU);
-	return MENU_CALLBACK_NOP; // TODO: this should probably be an arg
+	return MENU_CALLBACK_NOP;  // TODO: this should probably be an arg
 }
 
 static int Menu_options(MenuList* list);
 
 static int MenuList_freeItems(MenuList* list, int i) {
-	// TODO: what calls this? do menu's register for needing it? then call it on quit for each?
+	// TODO: what calls this? do menu's register for needing it? then call it on
+	// quit for each?
 	if (list->items) free(list->items);
 	return MENU_CALLBACK_NOP;
 }
@@ -3204,17 +3338,18 @@ static MenuList OptionFrontend_menu = {
 	.items = NULL,
 };
 static int OptionFrontend_openMenu(MenuList* list, int i) {
-	if (OptionFrontend_menu.items==NULL) {
+	if (OptionFrontend_menu.items == NULL) {
 		// TODO: where do I free this? I guess I don't :sweat_smile:
 		if (!config.frontend.enabled_count) {
 			int enabled_count = 0;
-			for (int i=0; i<config.frontend.count; i++) {
+			for (int i = 0; i < config.frontend.count; i++) {
 				if (!config.frontend.options[i].lock) enabled_count += 1;
 			}
 			config.frontend.enabled_count = enabled_count;
-			config.frontend.enabled_options = calloc(enabled_count+1, sizeof(Option*));
+			config.frontend.enabled_options =
+				calloc(enabled_count + 1, sizeof(Option*));
 			int j = 0;
-			for (int i=0; i<config.frontend.count; i++) {
+			for (int i = 0; i < config.frontend.count; i++) {
 				Option* item = &config.frontend.options[i];
 				if (item->lock) continue;
 				config.frontend.enabled_options[j] = item;
@@ -3222,8 +3357,9 @@ static int OptionFrontend_openMenu(MenuList* list, int i) {
 			}
 		}
 
-		OptionFrontend_menu.items = calloc(config.frontend.enabled_count+1, sizeof(MenuItem));
-		for (int j=0; j<config.frontend.enabled_count; j++) {
+		OptionFrontend_menu.items =
+			calloc(config.frontend.enabled_count + 1, sizeof(MenuItem));
+		for (int j = 0; j < config.frontend.enabled_count; j++) {
 			Option* option = config.frontend.enabled_options[j];
 			MenuItem* item = &OptionFrontend_menu.items[j];
 			item->key = option->key;
@@ -3232,16 +3368,15 @@ static int OptionFrontend_openMenu(MenuList* list, int i) {
 			item->value = option->value;
 			item->values = option->labels;
 		}
-	}
-	else {
+	} else {
 		// update values
-		for (int j=0; j<config.frontend.enabled_count; j++) {
+		for (int j = 0; j < config.frontend.enabled_count; j++) {
 			Option* option = config.frontend.enabled_options[j];
 			MenuItem* item = &OptionFrontend_menu.items[j];
 			item->value = option->value;
 		}
 	}
-	
+
 	Menu_options(&OptionFrontend_menu);
 	return MENU_CALLBACK_NOP;
 }
@@ -3249,46 +3384,51 @@ static int OptionFrontend_openMenu(MenuList* list, int i) {
 static int OptionEmulator_optionChanged(MenuList* list, int i) {
 	MenuItem* item = &list->items[i];
 	Option* option = OptionList_getOption(&config.core, item->key);
-	LOG_info("%s (%s) changed from `%s` (%s) to `%s` (%s)\n", item->name, item->key, 
-		item->values[option->value], option->values[option->value], 
-		item->values[item->value], option->values[item->value]
-	);
+	LOG_info("%s (%s) changed from `%s` (%s) to `%s` (%s)\n", item->name,
+			 item->key, item->values[option->value],
+			 option->values[option->value], item->values[item->value],
+			 option->values[item->value]);
 	OptionList_setOptionRawValue(&config.core, item->key, item->value);
 	return MENU_CALLBACK_NOP;
 }
 static int OptionEmulator_optionDetail(MenuList* list, int i) {
 	MenuItem* item = &list->items[i];
 	Option* option = OptionList_getOption(&config.core, item->key);
-	if (option->full) return Menu_message(option->full, (char*[]){ "B","BACK", NULL });
-	else return MENU_CALLBACK_NOP;
+	if (option->full)
+		return Menu_message(option->full, (char*[]){"B", "BACK", NULL});
+	else
+		return MENU_CALLBACK_NOP;
 }
 static MenuList OptionEmulator_menu = {
 	.type = MENU_FIXED,
-	.on_confirm = OptionEmulator_optionDetail, // TODO: this needs pagination to be truly useful
+	.on_confirm = OptionEmulator_optionDetail,	// TODO: this needs pagination
+												// to be truly useful
 	.on_change = OptionEmulator_optionChanged,
 	.items = NULL,
 };
 static int OptionEmulator_openMenu(MenuList* list, int i) {
-	if (OptionEmulator_menu.items==NULL) {
+	if (OptionEmulator_menu.items == NULL) {
 		// TODO: where do I free this? I guess I don't :sweat_smile:
 		if (!config.core.enabled_count) {
 			int enabled_count = 0;
-			for (int i=0; i<config.core.count; i++) {
+			for (int i = 0; i < config.core.count; i++) {
 				if (!config.core.options[i].lock) enabled_count += 1;
 			}
 			config.core.enabled_count = enabled_count;
-			config.core.enabled_options = calloc(enabled_count+1, sizeof(Option*));
+			config.core.enabled_options =
+				calloc(enabled_count + 1, sizeof(Option*));
 			int j = 0;
-			for (int i=0; i<config.core.count; i++) {
+			for (int i = 0; i < config.core.count; i++) {
 				Option* item = &config.core.options[i];
 				if (item->lock) continue;
 				config.core.enabled_options[j] = item;
 				j += 1;
 			}
 		}
-		
-		OptionEmulator_menu.items = calloc(config.core.enabled_count+1, sizeof(MenuItem));
-		for (int j=0; j<config.core.enabled_count; j++) {
+
+		OptionEmulator_menu.items =
+			calloc(config.core.enabled_count + 1, sizeof(MenuItem));
+		for (int j = 0; j < config.core.enabled_count; j++) {
 			Option* option = config.core.enabled_options[j];
 			MenuItem* item = &OptionEmulator_menu.items[j];
 			item->key = option->key;
@@ -3297,50 +3437,48 @@ static int OptionEmulator_openMenu(MenuList* list, int i) {
 			item->value = option->value;
 			item->values = option->labels;
 		}
-	}
-	else {
+	} else {
 		// update values
-		for (int j=0; j<config.core.enabled_count; j++) {
+		for (int j = 0; j < config.core.enabled_count; j++) {
 			Option* option = config.core.enabled_options[j];
 			MenuItem* item = &OptionEmulator_menu.items[j];
 			item->value = option->value;
 		}
 	}
-	
-	if (OptionEmulator_menu.items[0].name) { // TODO: why doesn't this just use (enabled_)count?
+
+	if (OptionEmulator_menu.items[0]
+			.name) {  // TODO: why doesn't this just use (enabled_)count?
 		Menu_options(&OptionEmulator_menu);
+	} else {
+		Menu_message("This core has no options.", (char*[]){"B", "BACK", NULL});
 	}
-	else {
-		Menu_message("This core has no options.", (char*[]){ "B","BACK", NULL });
-	}
-	
+
 	return MENU_CALLBACK_NOP;
 }
 
 int OptionControls_bind(MenuList* list, int i) {
 	MenuItem* item = &list->items[i];
-	if (item->values!=button_labels) {
+	if (item->values != button_labels) {
 		// LOG_info("changed gamepad_type\n");
 		return MENU_CALLBACK_NOP;
 	}
-	
+
 	ButtonMapping* button = &config.controls[item->id];
-	
+
 	int bound = 0;
 	while (!bound) {
 		GFX_startFrame();
 		PAD_poll();
-		
+
 		// NOTE: off by one because of the initial NONE value
-		for (int id=0; id<=LOCAL_BUTTON_COUNT; id++) {
-			if (PAD_justPressed(1 << (id-1))) {
+		for (int id = 0; id <= LOCAL_BUTTON_COUNT; id++) {
+			if (PAD_justPressed(1 << (id - 1))) {
 				item->value = id;
 				button->local = id - 1;
 				if (PAD_isPressed(BTN_MENU)) {
 					item->value += LOCAL_BUTTON_COUNT;
 					button->mod = 1;
-				}
-				else {
+				} else {
 					button->mod = 0;
 				}
 				bound = 1;
@@ -3354,8 +3492,8 @@ int OptionControls_bind(MenuList* list, int i) {
 }
 static int OptionControls_unbind(MenuList* list, int i) {
 	MenuItem* item = &list->items[i];
-	if (item->values!=button_labels) return MENU_CALLBACK_NOP;
-	
+	if (item->values != button_labels) return MENU_CALLBACK_NOP;
+
 	ButtonMapping* button = &config.controls[item->id];
 	button->local = -1;
 	button->mod = 0;
@@ -3363,7 +3501,7 @@ static int OptionControls_unbind(MenuList* list, int i) {
 }
 static int OptionControls_optionChanged(MenuList* list, int i) {
 	MenuItem* item = &list->items[i];
-	if (item->values!=gamepad_labels) return MENU_CALLBACK_NOP;
+	if (item->values != gamepad_labels) return MENU_CALLBACK_NOP;
 
 	if (has_custom_controllers) {
 		gamepad_type = item->value;
@@ -3374,22 +3512,24 @@ static int OptionControls_optionChanged(MenuList* list, int i) {
 }
 static MenuList OptionControls_menu = {
 	.type = MENU_INPUT,
-	.desc = "Press A to set and X to clear."
-		"\nSupports single button and MENU+button." // TODO: not supported on nano because POWER doubles as MENU
+	.desc =
+		"Press A to set and X to clear."
+		"\nSupports single button and MENU+button."	 // TODO: not supported on
+													 // nano because POWER
+													 // doubles as MENU
 	,
 	.on_confirm = OptionControls_bind,
 	.on_change = OptionControls_unbind,
-	.items = NULL
-};
+	.items = NULL};
 static int OptionControls_openMenu(MenuList* list, int i) {
 	LOG_info("OptionControls_openMenu\n");
 
-	if (OptionControls_menu.items==NULL) {
-		
+	if (OptionControls_menu.items == NULL) {
 		// TODO: where do I free this?
-		OptionControls_menu.items = calloc(RETRO_BUTTON_COUNT+1+has_custom_controllers, sizeof(MenuItem));
+		OptionControls_menu.items = calloc(
+			RETRO_BUTTON_COUNT + 1 + has_custom_controllers, sizeof(MenuItem));
 		int k = 0;
-		
+
 		if (has_custom_controllers) {
 			MenuItem* item = &OptionControls_menu.items[k++];
 			item->name = "Controller";
@@ -3398,13 +3538,14 @@ static int OptionControls_openMenu(MenuList* list, int i) {
 			item->values = gamepad_labels;
 			item->on_change = OptionControls_optionChanged;
 		}
-		
-		for (int j=0; config.controls[j].name; j++) {
+
+		for (int j = 0; config.controls[j].name; j++) {
 			ButtonMapping* button = &config.controls[j];
 			if (button->ignore) continue;
-			
-			LOG_info("\t%s (%i:%i)\n", button->name, button->local, button->retro);
-			
+
+			LOG_info("\t%s (%i:%i)\n", button->name, button->local,
+					 button->retro);
+
 			MenuItem* item = &OptionControls_menu.items[k++];
 			item->id = j;
 			item->name = button->name;
@@ -3413,20 +3554,19 @@ static int OptionControls_openMenu(MenuList* list, int i) {
 			if (button->mod) item->value += LOCAL_BUTTON_COUNT;
 			item->values = button_labels;
 		}
-	}
-	else {
+	} else {
 		// update values
 		int k = 0;
-		
+
 		if (has_custom_controllers) {
 			MenuItem* item = &OptionControls_menu.items[k++];
 			item->value = gamepad_type;
 		}
-		
-		for (int j=0; config.controls[j].name; j++) {
+
+		for (int j = 0; config.controls[j].name; j++) {
 			ButtonMapping* button = &config.controls[j];
 			if (button->ignore) continue;
-			
+
 			MenuItem* item = &OptionControls_menu.items[k++];
 			item->value = button->local + 1;
 			if (button->mod) item->value += LOCAL_BUTTON_COUNT;
@@ -3443,17 +3583,16 @@ static int OptionShortcuts_bind(MenuList* list, int i) {
 	while (!bound) {
 		GFX_startFrame();
 		PAD_poll();
-		
+
 		// NOTE: off by one because of the initial NONE value
-		for (int id=0; id<=LOCAL_BUTTON_COUNT; id++) {
-			if (PAD_justPressed(1 << (id-1))) {
+		for (int id = 0; id <= LOCAL_BUTTON_COUNT; id++) {
+			if (PAD_justPressed(1 << (id - 1))) {
 				item->value = id;
 				button->local = id - 1;
 				if (PAD_isPressed(BTN_MENU)) {
 					item->value += LOCAL_BUTTON_COUNT;
 					button->mod = 1;
-				}
-				else {
+				} else {
 					button->mod = 0;
 				}
 				bound = 1;
@@ -3474,26 +3613,35 @@ static int OptionShortcuts_unbind(MenuList* list, int i) {
 }
 static MenuList OptionShortcuts_menu = {
 	.type = MENU_INPUT,
-	.desc = "Press A to set and X to clear." 
-		"\nSupports single button and MENU+button." // TODO: not supported on nano because POWER doubles as MENU
+	.desc =
+		"Press A to set and X to clear."
+		"\nSupports single button and MENU+button."	 // TODO: not supported on
+													 // nano because POWER
+													 // doubles as MENU
 	,
 	.on_confirm = OptionShortcuts_bind,
 	.on_change = OptionShortcuts_unbind,
-	.items = NULL
-};
+	.items = NULL};
 static char* getSaveDesc(void) {
 	switch (config.loaded) {
-		case CONFIG_NONE:		return "Using defaults."; break;
-		case CONFIG_CONSOLE:	return "Using console config."; break;
-		case CONFIG_GAME:		return "Using game config."; break;
+		case CONFIG_NONE:
+			return "Using defaults.";
+			break;
+		case CONFIG_CONSOLE:
+			return "Using console config.";
+			break;
+		case CONFIG_GAME:
+			return "Using game config.";
+			break;
 	}
 	return NULL;
 }
 static int OptionShortcuts_openMenu(MenuList* list, int i) {
-	if (OptionShortcuts_menu.items==NULL) {
+	if (OptionShortcuts_menu.items == NULL) {
 		// TODO: where do I free this? I guess I don't :sweat_smile:
-		OptionShortcuts_menu.items = calloc(SHORTCUT_COUNT+1, sizeof(MenuItem));
-		for (int j=0; config.shortcuts[j].name; j++) {
+		OptionShortcuts_menu.items =
+			calloc(SHORTCUT_COUNT + 1, sizeof(MenuItem));
+		for (int j = 0; config.shortcuts[j].name; j++) {
 			ButtonMapping* button = &config.shortcuts[j];
 			MenuItem* item = &OptionShortcuts_menu.items[j];
 			item->id = j;
@@ -3503,10 +3651,9 @@ static int OptionShortcuts_openMenu(MenuList* list, int i) {
 			if (button->mod) item->value += LOCAL_BUTTON_COUNT;
 			item->values = button_labels;
 		}
-	}
-	else {
+	} else {
 		// update values
-		for (int j=0; config.shortcuts[j].name; j++) {
+		for (int j = 0; config.shortcuts[j].name; j++) {
 			ButtonMapping* button = &config.shortcuts[j];
 			MenuItem* item = &OptionShortcuts_menu.items[j];
 			item->value = button->local + 1;
@@ -3533,12 +3680,14 @@ static int OptionSaveChanges_onConfirm(MenuList* list, int i) {
 		}
 		default: {
 			Config_restore();
-			if (config.loaded) message = "Restored console defaults.";
-			else message = "Restored defaults.";
+			if (config.loaded)
+				message = "Restored console defaults.";
+			else
+				message = "Restored defaults.";
 			break;
 		}
 	}
-	Menu_message(message, (char*[]){ "A","OKAY", NULL });
+	Menu_message(message, (char*[]){"A", "OKAY", NULL});
 	OptionSaveChanges_updateDesc();
 	return MENU_CALLBACK_EXIT;
 }
@@ -3550,8 +3699,7 @@ static MenuList OptionSaveChanges_menu = {
 		{"Save for game"},
 		{"Restore defaults"},
 		{NULL},
-	}
-};
+	}};
 static int OptionSaveChanges_openMenu(MenuList* list, int i) {
 	OptionSaveChanges_updateDesc();
 	OptionSaveChanges_menu.desc = getSaveDesc();
@@ -3566,17 +3714,17 @@ static int OptionQuicksave_onConfirm(MenuList* list, int i) {
 
 static MenuList options_menu = {
 	.type = MENU_LIST,
-	.items = (MenuItem[]) {
-		{"Frontend", "MinUI (" BUILD_DATE " " BUILD_HASH ")",.on_confirm=OptionFrontend_openMenu},
-		{"Emulator",.on_confirm=OptionEmulator_openMenu},
-		{"Controls",.on_confirm=OptionControls_openMenu},
-		{"Shortcuts",.on_confirm=OptionShortcuts_openMenu}, 
-		{"Save Changes",.on_confirm=OptionSaveChanges_openMenu},
+	.items = (MenuItem[]){
+		{"Frontend", "MinUI (" BUILD_DATE " " BUILD_HASH ")",
+		 .on_confirm = OptionFrontend_openMenu},
+		{"Emulator", .on_confirm = OptionEmulator_openMenu},
+		{"Controls", .on_confirm = OptionControls_openMenu},
+		{"Shortcuts", .on_confirm = OptionShortcuts_openMenu},
+		{"Save Changes", .on_confirm = OptionSaveChanges_openMenu},
 		{NULL},
 		{NULL},
 		{NULL},
-	}
-};
+	}};
 
 static void OptionSaveChanges_updateDesc(void) {
 	options_menu.items[4].desc = getSaveDesc();
@@ -3592,410 +3740,434 @@ static int Menu_options(MenuList* list) {
 	int show_options = 1;
 	int show_settings = 0;
 	int await_input = 0;
-	
+
 	// dependent on option list offset top and bottom, eg. the gray triangles
-	int max_visible_options = (screen->h - ((SCALE1(PADDING + PILL_SIZE) * 2) + SCALE1(BUTTON_SIZE))) / SCALE1(BUTTON_SIZE); // 7 for 480, 10 for 720
-	
+	int max_visible_options = (screen->h - ((SCALE1(PADDING + PILL_SIZE) * 2) +
+											SCALE1(BUTTON_SIZE))) /
+							  SCALE1(BUTTON_SIZE);	// 7 for 480, 10 for 720
+
 	int count;
-	for (count=0; items[count].name; count++);
+	for (count = 0; items[count].name; count++);
 	int selected = 0;
 	int start = 0;
-	int end = MIN(count,max_visible_options);
+	int end = MIN(count, max_visible_options);
 	int visible_rows = end;
-	
+
 	OptionSaveChanges_updateDesc();
-	
+
 	int defer_menu = false;
 	while (show_options) {
 		if (await_input) {
 			defer_menu = true;
 			list->on_confirm(list, selected);
-			
+
 			selected += 1;
-			if (selected>=count) {
+			if (selected >= count) {
 				selected = 0;
 				start = 0;
 				end = visible_rows;
-			}
-			else if (selected>=end) {
+			} else if (selected >= end) {
 				start += 1;
 				end += 1;
 			}
 			dirty = 1;
 			await_input = false;
 		}
-		
+
 		GFX_startFrame();
 		PAD_poll();
-		
+
 		if (PAD_justRepeated(BTN_UP)) {
 			selected -= 1;
-			if (selected<0) {
+			if (selected < 0) {
 				selected = count - 1;
-				start = MAX(0,count - max_visible_options);
+				start = MAX(0, count - max_visible_options);
 				end = count;
-			}
-			else if (selected<start) {
+			} else if (selected < start) {
 				start -= 1;
 				end -= 1;
 			}
 			dirty = 1;
-		}
-		else if (PAD_justRepeated(BTN_DOWN)) {
+		} else if (PAD_justRepeated(BTN_DOWN)) {
 			selected += 1;
-			if (selected>=count) {
+			if (selected >= count) {
 				selected = 0;
 				start = 0;
 				end = visible_rows;
-			}
-			else if (selected>=end) {
+			} else if (selected >= end) {
 				start += 1;
 				end += 1;
 			}
 			dirty = 1;
-		}
-		else {
+		} else {
 			MenuItem* item = &items[selected];
-			if (item->values && item->values!=button_labels) { // not an input binding
+			if (item->values &&
+				item->values != button_labels) {  // not an input binding
 				if (PAD_justRepeated(BTN_LEFT)) {
-					if (item->value>0) item->value -= 1;
+					if (item->value > 0)
+						item->value -= 1;
 					else {
 						int j;
-						for (j=0; item->values[j]; j++);
+						for (j = 0; item->values[j]; j++);
 						item->value = j - 1;
 					}
-				
-					if (item->on_change) item->on_change(list, selected);
-					else if (list->on_change) list->on_change(list, selected);
-				
+
+					if (item->on_change)
+						item->on_change(list, selected);
+					else if (list->on_change)
+						list->on_change(list, selected);
+
 					dirty = 1;
-				}
-				else if (PAD_justRepeated(BTN_RIGHT)) {
-					if (item->values[item->value+1]) item->value += 1;
-					else item->value = 0;
-				
-					if (item->on_change) item->on_change(list, selected);
-					else if (list->on_change) list->on_change(list, selected);
-				
+				} else if (PAD_justRepeated(BTN_RIGHT)) {
+					if (item->values[item->value + 1])
+						item->value += 1;
+					else
+						item->value = 0;
+
+					if (item->on_change)
+						item->on_change(list, selected);
+					else if (list->on_change)
+						list->on_change(list, selected);
+
 					dirty = 1;
 				}
 			}
 		}
-		
+
 		// uint32_t now = SDL_GetTicks();
-		if (PAD_justPressed(BTN_B)) { // || PAD_tappedMenu(now)
+		if (PAD_justPressed(BTN_B)) {  // || PAD_tappedMenu(now)
 			show_options = 0;
-		}
-		else if (PAD_justPressed(BTN_A)) {
+		} else if (PAD_justPressed(BTN_A)) {
 			MenuItem* item = &items[selected];
 			int result = MENU_CALLBACK_NOP;
-			if (item->on_confirm) result = item->on_confirm(list, selected); // item-specific action, eg. Save for all games
-			else if (item->submenu) result = Menu_options(item->submenu); // drill down, eg. main options menu
-			// TODO: is there a way to defer on_confirm for MENU_INPUT so we can clear the currently set value to indicate it is awaiting input? 
-			// eg. set a flag to call on_confirm at the beginning of the next frame?
+			if (item->on_confirm)
+				result = item->on_confirm(
+					list,
+					selected);	// item-specific action, eg. Save for all games
+			else if (item->submenu)
+				result = Menu_options(
+					item->submenu);	 // drill down, eg. main options menu
+			// TODO: is there a way to defer on_confirm for MENU_INPUT so we can
+			// clear the currently set value to indicate it is awaiting input?
+			// eg. set a flag to call on_confirm at the beginning of the next
+			// frame?
 			else if (list->on_confirm) {
-				if (item->values==button_labels) await_input = 1; // button binding
-				else result = list->on_confirm(list, selected); // list-specific action, eg. show item detail view or input binding
+				if (item->values == button_labels)
+					await_input = 1;  // button binding
+				else
+					result = list->on_confirm(
+						list, selected);  // list-specific action, eg. show item
+										  // detail view or input binding
 			}
-			if (result==MENU_CALLBACK_EXIT) show_options = 0;
+			if (result == MENU_CALLBACK_EXIT)
+				show_options = 0;
 			else {
-				if (result==MENU_CALLBACK_NEXT_ITEM) {
+				if (result == MENU_CALLBACK_NEXT_ITEM) {
 					// copied from PAD_justRepeated(BTN_DOWN) above
 					selected += 1;
-					if (selected>=count) {
+					if (selected >= count) {
 						selected = 0;
 						start = 0;
 						end = visible_rows;
-					}
-					else if (selected>=end) {
+					} else if (selected >= end) {
 						start += 1;
 						end += 1;
 					}
 				}
 				dirty = 1;
 			}
-		}
-		else if (type==MENU_INPUT) {
+		} else if (type == MENU_INPUT) {
 			if (PAD_justPressed(BTN_X)) {
 				MenuItem* item = &items[selected];
 				item->value = 0;
-				
-				if (item->on_change) item->on_change(list, selected);
-				else if (list->on_change) list->on_change(list, selected);
-				
+
+				if (item->on_change)
+					item->on_change(list, selected);
+				else if (list->on_change)
+					list->on_change(list, selected);
+
 				// copied from PAD_justRepeated(BTN_DOWN) above
 				selected += 1;
-				if (selected>=count) {
+				if (selected >= count) {
 					selected = 0;
 					start = 0;
 					end = visible_rows;
-				}
-				else if (selected>=end) {
+				} else if (selected >= end) {
 					start += 1;
 					end += 1;
 				}
 				dirty = 1;
 			}
 		}
-		
-		if (!defer_menu) PWR_update(&dirty, &show_settings, Menu_beforeSleep, Menu_afterSleep);
-		
+
+		if (!defer_menu)
+			PWR_update(&dirty, &show_settings, Menu_beforeSleep,
+					   Menu_afterSleep);
+
 		if (defer_menu && PAD_justReleased(BTN_MENU)) defer_menu = false;
-		
+
 		if (dirty) {
 			GFX_clear(screen);
 			GFX_blitHardwareGroup(screen, show_settings);
-			
+
 			char* desc = NULL;
 			SDL_Surface* text;
 
-			if (type==MENU_LIST) {
+			if (type == MENU_LIST) {
 				int mw = list->max_width;
 				if (!mw) {
 					// get the width of the widest item
-					for (int i=0; i<count; i++) {
+					for (int i = 0; i < count; i++) {
 						MenuItem* item = &items[i];
 						int w = 0;
 						TTF_SizeUTF8(font.small, item->name, &w, NULL);
-						w += SCALE1(OPTION_PADDING*2);
-						if (w>mw) mw = w;
+						w += SCALE1(OPTION_PADDING * 2);
+						if (w > mw) mw = w;
 					}
 					// cache the result
-					list->max_width = mw = MIN(mw, screen->w - SCALE1(PADDING *2));
+					list->max_width = mw =
+						MIN(mw, screen->w - SCALE1(PADDING * 2));
 				}
-				
+
 				int ox = (screen->w - mw) / 2;
 				int oy = SCALE1(PADDING + PILL_SIZE);
 				int selected_row = selected - start;
-				for (int i=start,j=0; i<end; i++,j++) {
+				for (int i = start, j = 0; i < end; i++, j++) {
 					MenuItem* item = &items[i];
 					SDL_Color text_color = COLOR_WHITE;
 
-					// int ox = (screen->w - w) / 2; // if we're centering these (but I don't think we should after seeing it)
-					if (j==selected_row) {
+					// int ox = (screen->w - w) / 2; // if we're centering these
+					// (but I don't think we should after seeing it)
+					if (j == selected_row) {
 						// move out of conditional if centering
 						int w = 0;
 						TTF_SizeUTF8(font.small, item->name, &w, NULL);
-						w += SCALE1(OPTION_PADDING*2);
-						
-						GFX_blitPill(ASSET_BUTTON, screen, &(SDL_Rect){
-							ox,
-							oy+SCALE1(j*BUTTON_SIZE),
-							w,
-							SCALE1(BUTTON_SIZE)
-						});
+						w += SCALE1(OPTION_PADDING * 2);
+
+						GFX_blitPill(
+							ASSET_BUTTON, screen,
+							&(SDL_Rect){ox, oy + SCALE1(j * BUTTON_SIZE), w,
+										SCALE1(BUTTON_SIZE)});
 						text_color = COLOR_BLACK;
-						
+
 						if (item->desc) desc = item->desc;
 					}
-					text = TTF_RenderUTF8_Blended(font.small, item->name, text_color);
-					SDL_BlitSurface(text, NULL, screen, &(SDL_Rect){
-						ox+SCALE1(OPTION_PADDING),
-						oy+SCALE1((j*BUTTON_SIZE)+1)
-					});
+					text = TTF_RenderUTF8_Blended(font.small, item->name,
+												  text_color);
+					SDL_BlitSurface(
+						text, NULL, screen,
+						&(SDL_Rect){ox + SCALE1(OPTION_PADDING),
+									oy + SCALE1((j * BUTTON_SIZE) + 1)});
 					SDL_FreeSurface(text);
 				}
-			}
-			else if (type==MENU_FIXED) {
+			} else if (type == MENU_FIXED) {
 				// NOTE: no need to calculate max width
-				int mw = screen->w - SCALE1(PADDING*2);
+				int mw = screen->w - SCALE1(PADDING * 2);
 				// int lw,rw;
 				// lw = rw = mw / 2;
-				int ox,oy;
+				int ox, oy;
 				ox = oy = SCALE1(PADDING);
 				oy += SCALE1(PILL_SIZE);
-				
+
 				int selected_row = selected - start;
-				for (int i=start,j=0; i<end; i++,j++) {
+				for (int i = start, j = 0; i < end; i++, j++) {
 					MenuItem* item = &items[i];
 					SDL_Color text_color = COLOR_WHITE;
 
-					if (j==selected_row) {
+					if (j == selected_row) {
 						// gray pill
-						GFX_blitPill(ASSET_OPTION, screen, &(SDL_Rect){
-							ox,
-							oy+SCALE1(j*BUTTON_SIZE),
-							mw,
-							SCALE1(BUTTON_SIZE)
-						});
+						GFX_blitPill(
+							ASSET_OPTION, screen,
+							&(SDL_Rect){ox, oy + SCALE1(j * BUTTON_SIZE), mw,
+										SCALE1(BUTTON_SIZE)});
 					}
-					
-					if (item->value>=0) {
-						text = TTF_RenderUTF8_Blended(font.tiny, item->values[item->value], COLOR_WHITE); // always white
-						SDL_BlitSurface(text, NULL, screen, &(SDL_Rect){
-							ox + mw - text->w - SCALE1(OPTION_PADDING),
-							oy+SCALE1((j*BUTTON_SIZE)+3)
-						});
+
+					if (item->value >= 0) {
+						text = TTF_RenderUTF8_Blended(
+							font.tiny, item->values[item->value],
+							COLOR_WHITE);  // always white
+						SDL_BlitSurface(
+							text, NULL, screen,
+							&(SDL_Rect){
+								ox + mw - text->w - SCALE1(OPTION_PADDING),
+								oy + SCALE1((j * BUTTON_SIZE) + 3)});
 						SDL_FreeSurface(text);
 					}
-					
-					// TODO: blit a black pill on unselected rows (to cover longer item->values?) or truncate longer item->values?
-					if (j==selected_row) {
+
+					// TODO: blit a black pill on unselected rows (to cover
+					// longer item->values?) or truncate longer item->values?
+					if (j == selected_row) {
 						// white pill
 						int w = 0;
 						TTF_SizeUTF8(font.small, item->name, &w, NULL);
-						w += SCALE1(OPTION_PADDING*2);
-						GFX_blitPill(ASSET_BUTTON, screen, &(SDL_Rect){
-							ox,
-							oy+SCALE1(j*BUTTON_SIZE),
-							w,
-							SCALE1(BUTTON_SIZE)
-						});
+						w += SCALE1(OPTION_PADDING * 2);
+						GFX_blitPill(
+							ASSET_BUTTON, screen,
+							&(SDL_Rect){ox, oy + SCALE1(j * BUTTON_SIZE), w,
+										SCALE1(BUTTON_SIZE)});
 						text_color = COLOR_BLACK;
-						
+
 						if (item->desc) desc = item->desc;
 					}
-					text = TTF_RenderUTF8_Blended(font.small, item->name, text_color);
-					SDL_BlitSurface(text, NULL, screen, &(SDL_Rect){
-						ox+SCALE1(OPTION_PADDING),
-						oy+SCALE1((j*BUTTON_SIZE)+1)
-					});
+					text = TTF_RenderUTF8_Blended(font.small, item->name,
+												  text_color);
+					SDL_BlitSurface(
+						text, NULL, screen,
+						&(SDL_Rect){ox + SCALE1(OPTION_PADDING),
+									oy + SCALE1((j * BUTTON_SIZE) + 1)});
 					SDL_FreeSurface(text);
 				}
-			}
-			else if (type==MENU_VAR || type==MENU_INPUT) {
+			} else if (type == MENU_VAR || type == MENU_INPUT) {
 				int mw = list->max_width;
 				if (!mw) {
 					// get the width of the widest row
 					int mrw = 0;
-					for (int i=0; i<count; i++) {
+					for (int i = 0; i < count; i++) {
 						MenuItem* item = &items[i];
 						int w = 0;
 						int lw = 0;
 						int rw = 0;
 						TTF_SizeUTF8(font.small, item->name, &lw, NULL);
-						
+
 						// every value list in an input table is the same
 						// so only calculate rw for the first item...
-						if (!mrw || type!=MENU_INPUT) {
-							for (int j=0; item->values[j]; j++) {
-								TTF_SizeUTF8(font.tiny, item->values[j], &rw, NULL);
-								if (lw+rw>w) w = lw+rw;
-								if (rw>mrw) mrw = rw;
+						if (!mrw || type != MENU_INPUT) {
+							for (int j = 0; item->values[j]; j++) {
+								TTF_SizeUTF8(font.tiny, item->values[j], &rw,
+											 NULL);
+								if (lw + rw > w) w = lw + rw;
+								if (rw > mrw) mrw = rw;
 							}
-						}
-						else {
+						} else {
 							w = lw + mrw;
 						}
-						w += SCALE1(OPTION_PADDING*4);
-						if (w>mw) mw = w;
+						w += SCALE1(OPTION_PADDING * 4);
+						if (w > mw) mw = w;
 					}
 					fflush(stdout);
 					// cache the result
-					list->max_width = mw = MIN(mw, screen->w - SCALE1(PADDING *2));
+					list->max_width = mw =
+						MIN(mw, screen->w - SCALE1(PADDING * 2));
 				}
-				
+
 				int ox = (screen->w - mw) / 2;
 				int oy = SCALE1(PADDING + PILL_SIZE);
 				int selected_row = selected - start;
-				for (int i=start,j=0; i<end; i++,j++) {
+				for (int i = start, j = 0; i < end; i++, j++) {
 					MenuItem* item = &items[i];
 					SDL_Color text_color = COLOR_WHITE;
 
-					if (j==selected_row) {
+					if (j == selected_row) {
 						// gray pill
-						GFX_blitPill(ASSET_OPTION, screen, &(SDL_Rect){
-							ox,
-							oy+SCALE1(j*BUTTON_SIZE),
-							mw,
-							SCALE1(BUTTON_SIZE)
-						});
-						
+						GFX_blitPill(
+							ASSET_OPTION, screen,
+							&(SDL_Rect){ox, oy + SCALE1(j * BUTTON_SIZE), mw,
+										SCALE1(BUTTON_SIZE)});
+
 						// white pill
 						int w = 0;
 						TTF_SizeUTF8(font.small, item->name, &w, NULL);
-						w += SCALE1(OPTION_PADDING*2);
-						GFX_blitPill(ASSET_BUTTON, screen, &(SDL_Rect){
-							ox,
-							oy+SCALE1(j*BUTTON_SIZE),
-							w,
-							SCALE1(BUTTON_SIZE)
-						});
+						w += SCALE1(OPTION_PADDING * 2);
+						GFX_blitPill(
+							ASSET_BUTTON, screen,
+							&(SDL_Rect){ox, oy + SCALE1(j * BUTTON_SIZE), w,
+										SCALE1(BUTTON_SIZE)});
 						text_color = COLOR_BLACK;
-						
+
 						if (item->desc) desc = item->desc;
 					}
-					text = TTF_RenderUTF8_Blended(font.small, item->name, text_color);
-					SDL_BlitSurface(text, NULL, screen, &(SDL_Rect){
-						ox+SCALE1(OPTION_PADDING),
-						oy+SCALE1((j*BUTTON_SIZE)+1)
-					});
+					text = TTF_RenderUTF8_Blended(font.small, item->name,
+												  text_color);
+					SDL_BlitSurface(
+						text, NULL, screen,
+						&(SDL_Rect){ox + SCALE1(OPTION_PADDING),
+									oy + SCALE1((j * BUTTON_SIZE) + 1)});
 					SDL_FreeSurface(text);
-					
-					if (await_input && j==selected_row) {
+
+					if (await_input && j == selected_row) {
 						// buh
-					}
-					else if (item->value>=0) {
-						text = TTF_RenderUTF8_Blended(font.tiny, item->values[item->value], COLOR_WHITE); // always white
-						SDL_BlitSurface(text, NULL, screen, &(SDL_Rect){
-							ox + mw - text->w - SCALE1(OPTION_PADDING),
-							oy+SCALE1((j*BUTTON_SIZE)+3)
-						});
+					} else if (item->value >= 0) {
+						text = TTF_RenderUTF8_Blended(
+							font.tiny, item->values[item->value],
+							COLOR_WHITE);  // always white
+						SDL_BlitSurface(
+							text, NULL, screen,
+							&(SDL_Rect){
+								ox + mw - text->w - SCALE1(OPTION_PADDING),
+								oy + SCALE1((j * BUTTON_SIZE) + 3)});
 						SDL_FreeSurface(text);
 					}
 				}
 			}
-			
-			if (count>max_visible_options) {
-				#define SCROLL_WIDTH 24
-				#define SCROLL_HEIGHT 4
-				int ox = (screen->w - SCALE1(SCROLL_WIDTH))/2;
+
+			if (count > max_visible_options) {
+#define SCROLL_WIDTH 24
+#define SCROLL_HEIGHT 4
+				int ox = (screen->w - SCALE1(SCROLL_WIDTH)) / 2;
 				int oy = SCALE1((PILL_SIZE - SCROLL_HEIGHT) / 2);
-				if (start>0) GFX_blitAsset(ASSET_SCROLL_UP,   NULL, screen, &(SDL_Rect){ox, SCALE1(PADDING) + oy});
-				if (end<count) GFX_blitAsset(ASSET_SCROLL_DOWN, NULL, screen, &(SDL_Rect){ox, screen->h - SCALE1(PADDING + PILL_SIZE + BUTTON_SIZE) + oy});
+				if (start > 0)
+					GFX_blitAsset(ASSET_SCROLL_UP, NULL, screen,
+								  &(SDL_Rect){ox, SCALE1(PADDING) + oy});
+				if (end < count)
+					GFX_blitAsset(
+						ASSET_SCROLL_DOWN, NULL, screen,
+						&(SDL_Rect){
+							ox, screen->h -
+									SCALE1(PADDING + PILL_SIZE + BUTTON_SIZE) +
+									oy});
 			}
-			
+
 			if (!desc && list->desc) desc = list->desc;
-			
+
 			if (desc) {
-				int w,h;
-				GFX_sizeText(font.tiny, desc, SCALE1(12), &w,&h);
-				GFX_blitText(font.tiny, desc, SCALE1(12), COLOR_WHITE, screen, &(SDL_Rect){
-					(screen->w - w) / 2,
-					screen->h - SCALE1(PADDING) - h,
-					w,h
-				});
+				int w, h;
+				GFX_sizeText(font.tiny, desc, SCALE1(12), &w, &h);
+				GFX_blitText(
+					font.tiny, desc, SCALE1(12), COLOR_WHITE, screen,
+					&(SDL_Rect){(screen->w - w) / 2,
+								screen->h - SCALE1(PADDING) - h, w, h});
 			}
-			
+
 			GFX_flip(screen);
 			dirty = 0;
-		}
-		else GFX_sync();
+		} else
+			GFX_sync();
 		hdmimon();
 	}
-	
+
 	// GFX_clearAll();
 	// GFX_flip(screen);
-	
+
 	return 0;
 }
 
 static void Menu_scale(SDL_Surface* src, SDL_Surface* dst) {
-	// LOG_info("Menu_scale src: %ix%i dst: %ix%i\n", src->w,src->h,dst->w,dst->h);
-	
+	// LOG_info("Menu_scale src: %ix%i dst: %ix%i\n",
+	// src->w,src->h,dst->w,dst->h);
+
 	uint16_t* s = src->pixels;
 	uint16_t* d = dst->pixels;
-	
+
 	int sw = src->w;
 	int sh = src->h;
 	int sp = src->pitch / FIXED_BPP;
-	
+
 	int dw = dst->w;
 	int dh = dst->h;
 	int dp = dst->pitch / FIXED_BPP;
-	
+
 	int rx = 0;
 	int ry = 0;
 	int rw = dw;
 	int rh = dh;
-	
+
 	int scaling = screen_scaling;
-	if (scaling==SCALE_CROPPED && DEVICE_WIDTH==HDMI_WIDTH) {
+	if (scaling == SCALE_CROPPED && DEVICE_WIDTH == HDMI_WIDTH) {
 		scaling = SCALE_NATIVE;
 	}
-	if (scaling==SCALE_NATIVE) {
+	if (scaling == SCALE_NATIVE) {
 		// LOG_info("native\n");
-		
+
 		rx = renderer.dst_x;
 		ry = renderer.dst_y;
 		rw = renderer.src_w;
@@ -4004,24 +4176,22 @@ static void Menu_scale(SDL_Surface* src, SDL_Surface* dst) {
 			// LOG_info("scale: %i\n", renderer.scale);
 			rw *= renderer.scale;
 			rh *= renderer.scale;
-		}
-		else {
+		} else {
 			// LOG_info("forced crop\n"); // eg. fc on nano, vb on smart
 			rw -= renderer.src_x * 2;
 			rh -= renderer.src_y * 2;
 			sw = rw;
 			sh = rh;
 		}
-		
-		if (dw==DEVICE_WIDTH/2) {
+
+		if (dw == DEVICE_WIDTH / 2) {
 			// LOG_info("halve\n");
 			rx /= 2;
 			ry /= 2;
 			rw /= 2;
 			rh /= 2;
 		}
-	}
-	else if (scaling==SCALE_CROPPED) {
+	} else if (scaling == SCALE_CROPPED) {
 		// LOG_info("cropped\n");
 		sw -= renderer.src_x * 2;
 		sh -= renderer.src_y * 2;
@@ -4030,8 +4200,8 @@ static void Menu_scale(SDL_Surface* src, SDL_Surface* dst) {
 		ry = renderer.dst_y;
 		rw = sw * renderer.scale;
 		rh = sh * renderer.scale;
-		
-		if (dw==DEVICE_WIDTH/2) {
+
+		if (dw == DEVICE_WIDTH / 2) {
 			// LOG_info("halve\n");
 			rx /= 2;
 			ry /= 2;
@@ -4039,36 +4209,35 @@ static void Menu_scale(SDL_Surface* src, SDL_Surface* dst) {
 			rh /= 2;
 		}
 	}
-	
-	if (scaling==SCALE_ASPECT || rw>dw || rh>dh) {
+
+	if (scaling == SCALE_ASPECT || rw > dw || rh > dh) {
 		// LOG_info("aspect\n");
 		double fixed_aspect_ratio = ((double)DEVICE_WIDTH) / DEVICE_HEIGHT;
 		int core_aspect = core.aspect_ratio * 1000;
 		int fixed_aspect = fixed_aspect_ratio * 1000;
-		
-		if (core_aspect>fixed_aspect) {
+
+		if (core_aspect > fixed_aspect) {
 			// LOG_info("letterbox\n");
 			rw = dw;
 			rh = rw / core.aspect_ratio;
-			rh += rh%2;
-		}
-		else if (core_aspect<fixed_aspect) {
+			rh += rh % 2;
+		} else if (core_aspect < fixed_aspect) {
 			// LOG_info("pillarbox\n");
 			rh = dh;
 			rw = rh * core.aspect_ratio;
-			rw += rw%2;
-			rw = (rw/8)*8; // probably necessary here since we're not scaling by an integer
-		}
-		else {
+			rw += rw % 2;
+			rw = (rw / 8) * 8;	// probably necessary here since we're not
+								// scaling by an integer
+		} else {
 			// LOG_info("perfect match\n");
 			rw = dw;
 			rh = dh;
 		}
-		
+
 		rx = (dw - rw) / 2;
 		ry = (dh - rh) / 2;
 	}
-	
+
 	// LOG_info("Menu_scale (r): %i,%i %ix%i\n",rx,ry,rw,rh);
 	// LOG_info("offset: %i,%i\n", renderer.src_x, renderer.src_y);
 
@@ -4082,34 +4251,34 @@ static void Menu_scale(SDL_Surface* src, SDL_Surface* dst) {
 	int sr = 0;
 	int dr = ry * dp;
 	int cp = dp * FIXED_BPP;
-	
-	// LOG_info("Menu_scale (s): %i,%i %ix%i\n",sx,sy,sw,sh);
-	// LOG_info("mx:%i my:%i sx>>16:%i sy>>16:%i\n",mx,my,((sx+mx) >> 16),((sy+my) >> 16));
 
-	for (int dy=0; dy<rh; dy++) {
+	// LOG_info("Menu_scale (s): %i,%i %ix%i\n",sx,sy,sw,sh);
+	// LOG_info("mx:%i my:%i sx>>16:%i sy>>16:%i\n",mx,my,((sx+mx) >>
+	// 16),((sy+my) >> 16));
+
+	for (int dy = 0; dy < rh; dy++) {
 		sx = ox;
 		sr = (sy >> 16) * sp;
-		if (sr==lr) {
-			memcpy(d+dr,d+dr-dp,cp);
-		}
-		else {
-	        for (int dx=0; dx<rw; dx++) {
-	            d[dr + rx + dx] = s[sr + (sx >> 16)];
+		if (sr == lr) {
+			memcpy(d + dr, d + dr - dp, cp);
+		} else {
+			for (int dx = 0; dx < rw; dx++) {
+				d[dr + rx + dx] = s[sr + (sx >> 16)];
 				sx += mx;
-	        }
+			}
 		}
 		lr = sr;
 		sy += my;
 		dr += dp;
-    }
-	
+	}
+
 	// LOG_info("successful\n");
 }
 
 static void Menu_initState(void) {
 	if (exists(menu.slot_path)) menu.slot = getInt(menu.slot_path);
-	if (menu.slot==8) menu.slot = 0;
-	
+	if (menu.slot == 8) menu.slot = 0;
+
 	menu.save_exists = 0;
 	menu.preview_exists = 0;
 }
@@ -4124,34 +4293,40 @@ static void Menu_updateState(void) {
 
 	state_slot = last_slot;
 
-	sprintf(menu.bmp_path, "%s/%s.%d.bmp", menu.minui_dir, game.name, menu.slot);
-	sprintf(menu.txt_path, "%s/%s.%d.txt", menu.minui_dir, game.name, menu.slot);
-	
+	sprintf(menu.bmp_path, "%s/%s.%d.bmp", menu.minui_dir, game.name,
+			menu.slot);
+	sprintf(menu.txt_path, "%s/%s.%d.txt", menu.minui_dir, game.name,
+			menu.slot);
+
 	menu.save_exists = exists(save_path);
 	menu.preview_exists = menu.save_exists && exists(menu.bmp_path);
 
 	// LOG_info("save_path: %s (%i)\n", save_path, menu.save_exists);
-	// LOG_info("bmp_path: %s txt_path: %s (%i)\n", menu.bmp_path, menu.txt_path, menu.preview_exists);
+	// LOG_info("bmp_path: %s txt_path: %s (%i)\n", menu.bmp_path,
+	// menu.txt_path, menu.preview_exists);
 }
 static void Menu_saveState(void) {
 	// LOG_info("Menu_saveState\n");
 
 	Menu_updateState();
-	
+
 	if (menu.total_discs) {
 		char* disc_path = menu.disc_paths[menu.disc];
 		putFile(menu.txt_path, disc_path + strlen(menu.base_path));
 	}
-	
+
 	SDL_Surface* bitmap = menu.bitmap;
-	if (!bitmap) bitmap = SDL_CreateRGBSurfaceFrom(renderer.src, renderer.true_w, renderer.true_h, FIXED_DEPTH, renderer.src_p, RGBA_MASK_565);
+	if (!bitmap)
+		bitmap = SDL_CreateRGBSurfaceFrom(renderer.src, renderer.true_w,
+										  renderer.true_h, FIXED_DEPTH,
+										  renderer.src_p, RGBA_MASK_565);
 	SDL_RWops* out = SDL_RWFromFile(menu.bmp_path, "wb");
 	SDL_SaveBMP_RW(bitmap, out, 1);
-	
+
 	// LOG_info("%s %ix%i\n", menu.bmp_path, bitmap->w,bitmap->h);
-	
-	if (bitmap!=menu.bitmap) SDL_FreeSurface(bitmap);
-	
+
+	if (bitmap != menu.bitmap) SDL_FreeSurface(bitmap);
+
 	state_slot = menu.slot;
 	putInt(menu.slot_path, menu.slot);
 	State_write();
@@ -4160,22 +4335,24 @@ static void Menu_loadState(void) {
 	// LOG_info("Menu_loadState\n");
 
 	Menu_updateState();
-	
+
 	if (menu.save_exists) {
 		if (menu.total_discs) {
 			char slot_disc_name[256];
 			getFile(menu.txt_path, slot_disc_name, 256);
-		
+
 			char slot_disc_path[256];
-			if (slot_disc_name[0]=='/') strcpy(slot_disc_path, slot_disc_name);
-			else sprintf(slot_disc_path, "%s%s", menu.base_path, slot_disc_name);
-		
+			if (slot_disc_name[0] == '/')
+				strcpy(slot_disc_path, slot_disc_name);
+			else
+				sprintf(slot_disc_path, "%s%s", menu.base_path, slot_disc_name);
+
 			char* disc_path = menu.disc_paths[menu.disc];
 			if (!exactMatch(slot_disc_path, disc_path)) {
 				Game_changeDisc(slot_disc_path);
 			}
 		}
-	
+
 		state_slot = menu.slot;
 		putInt(menu.slot_path, menu.slot);
 		State_read();
@@ -4193,25 +4370,25 @@ static char* getAlias(char* path, char* alias) {
 		strcpy(tmp, "map.txt");
 		// LOG_info("map_path: %s\n", map_path);
 	}
-	char* file_name = strrchr(path,'/');
+	char* file_name = strrchr(path, '/');
 	if (file_name) file_name += 1;
 	// LOG_info("file_name: %s\n", file_name);
-	
+
 	if (exists(map_path)) {
 		FILE* file = fopen(map_path, "r");
 		if (file) {
 			char line[256];
-			while (fgets(line,256,file)!=NULL) {
+			while (fgets(line, 256, file) != NULL) {
 				normalizeNewline(line);
 				trimTrailingNewlines(line);
-				if (strlen(line)==0) continue; // skip empty lines
-			
-				tmp = strchr(line,'\t');
+				if (strlen(line) == 0) continue;  // skip empty lines
+
+				tmp = strchr(line, '\t');
 				if (tmp) {
 					tmp[0] = '\0';
 					char* key = line;
-					char* value = tmp+1;
-					if (exactMatch(file_name,key)) {
+					char* value = tmp + 1;
+					if (exactMatch(file_name, key)) {
 						strcpy(alias, value);
 						break;
 					}
@@ -4223,338 +4400,357 @@ static char* getAlias(char* path, char* alias) {
 }
 
 static void Menu_loop(void) {
-	menu.bitmap = SDL_CreateRGBSurfaceFrom(renderer.src, renderer.true_w, renderer.true_h, FIXED_DEPTH, renderer.src_p, RGBA_MASK_565);
+	menu.bitmap =
+		SDL_CreateRGBSurfaceFrom(renderer.src, renderer.true_w, renderer.true_h,
+								 FIXED_DEPTH, renderer.src_p, RGBA_MASK_565);
 	// LOG_info("Menu_loop:menu.bitmap %ix%i\n", menu.bitmap->w,menu.bitmap->h);
-	
-	SDL_Surface* backing = SDL_CreateRGBSurface(SDL_SWSURFACE,DEVICE_WIDTH,DEVICE_HEIGHT,FIXED_DEPTH,RGBA_MASK_565); 
+
+	SDL_Surface* backing = SDL_CreateRGBSurface(
+		SDL_SWSURFACE, DEVICE_WIDTH, DEVICE_HEIGHT, FIXED_DEPTH, RGBA_MASK_565);
 	Menu_scale(menu.bitmap, backing);
-	
+
 	int restore_w = screen->w;
 	int restore_h = screen->h;
 	int restore_p = screen->pitch;
-	if (restore_w!=DEVICE_WIDTH || restore_h!=DEVICE_HEIGHT) {
-		screen = GFX_resize(DEVICE_WIDTH,DEVICE_HEIGHT,DEVICE_PITCH);
+	if (restore_w != DEVICE_WIDTH || restore_h != DEVICE_HEIGHT) {
+		screen = GFX_resize(DEVICE_WIDTH, DEVICE_HEIGHT, DEVICE_PITCH);
 	}
-	
+
 	SRAM_write();
 	RTC_write();
 	PWR_warn(0);
 	if (!HAS_POWER_BUTTON) PWR_enableSleep();
-	PWR_setCPUSpeed(CPU_SPEED_MENU); // set Hz directly
+	PWR_setCPUSpeed(CPU_SPEED_MENU);  // set Hz directly
 	GFX_setVsync(VSYNC_STRICT);
 	GFX_setEffect(EFFECT_NONE);
-	
+
 	int rumble_strength = VIB_getStrength();
 	VIB_setStrength(0);
-	
+
 	PWR_enableAutosleep();
 	PAD_reset();
-	
+
 	// if (!HAS_POWER_BUTTON && !HAS_POWEROFF_BUTTON) {
 	// 	MenuItem* item = &options_menu.items[5];
 	// 	item->name = "Quicksave";
 	// 	item->desc = "Automatically resume current state next power on.";
 	// 	item->on_confirm = OptionQuicksave_onConfirm;
 	// }
-	
+
 	// path and string things
 	char* tmp;
-	char rom_name[256]; // without extension or cruft
+	char rom_name[256];	 // without extension or cruft
 	getDisplayName(game.name, rom_name);
 	getAlias(game.path, rom_name);
-	
+
 	int rom_disc = -1;
 	char disc_name[16];
 	if (menu.total_discs) {
 		rom_disc = menu.disc;
-		sprintf(disc_name, "Disc %i", menu.disc+1);
+		sprintf(disc_name, "Disc %i", menu.disc + 1);
 	}
-		
-	int selected = 0; // resets every launch
+
+	int selected = 0;  // resets every launch
 	Menu_initState();
-	
-	int status = STATUS_CONT; // TODO: no longer used?
+
+	int status = STATUS_CONT;  // TODO: no longer used?
 	int show_setting = 0;
 	int dirty = 1;
 	int ignore_menu = 0;
 	int menu_start = 0;
-	
-	SDL_Surface* preview = SDL_CreateRGBSurface(SDL_SWSURFACE,DEVICE_WIDTH/2,DEVICE_HEIGHT/2,FIXED_DEPTH,RGBA_MASK_565); // TODO: retain until changed?
-	
+
+	SDL_Surface* preview = SDL_CreateRGBSurface(
+		SDL_SWSURFACE, DEVICE_WIDTH / 2, DEVICE_HEIGHT / 2, FIXED_DEPTH,
+		RGBA_MASK_565);	 // TODO: retain until changed?
+
 	while (show_menu) {
 		GFX_startFrame();
 		uint32_t now = SDL_GetTicks();
 
 		PAD_poll();
-		
+
 		if (PAD_justPressed(BTN_UP)) {
 			selected -= 1;
-			if (selected<0) selected += MENU_ITEM_COUNT;
+			if (selected < 0) selected += MENU_ITEM_COUNT;
 			dirty = 1;
-		}
-		else if (PAD_justPressed(BTN_DOWN)) {
+		} else if (PAD_justPressed(BTN_DOWN)) {
 			selected += 1;
-			if (selected>=MENU_ITEM_COUNT) selected -= MENU_ITEM_COUNT;
+			if (selected >= MENU_ITEM_COUNT) selected -= MENU_ITEM_COUNT;
 			dirty = 1;
-		}
-		else if (PAD_justPressed(BTN_LEFT)) {
-			if (menu.total_discs>1 && selected==ITEM_CONT) {
+		} else if (PAD_justPressed(BTN_LEFT)) {
+			if (menu.total_discs > 1 && selected == ITEM_CONT) {
 				menu.disc -= 1;
-				if (menu.disc<0) menu.disc += menu.total_discs;
+				if (menu.disc < 0) menu.disc += menu.total_discs;
 				dirty = 1;
-				sprintf(disc_name, "Disc %i", menu.disc+1);
-			}
-			else if (selected==ITEM_SAVE || selected==ITEM_LOAD) {
+				sprintf(disc_name, "Disc %i", menu.disc + 1);
+			} else if (selected == ITEM_SAVE || selected == ITEM_LOAD) {
 				menu.slot -= 1;
-				if (menu.slot<0) menu.slot += MENU_SLOT_COUNT;
+				if (menu.slot < 0) menu.slot += MENU_SLOT_COUNT;
 				dirty = 1;
 			}
-		}
-		else if (PAD_justPressed(BTN_RIGHT)) {
-			if (menu.total_discs>1 && selected==ITEM_CONT) {
+		} else if (PAD_justPressed(BTN_RIGHT)) {
+			if (menu.total_discs > 1 && selected == ITEM_CONT) {
 				menu.disc += 1;
-				if (menu.disc==menu.total_discs) menu.disc -= menu.total_discs;
+				if (menu.disc == menu.total_discs)
+					menu.disc -= menu.total_discs;
 				dirty = 1;
-				sprintf(disc_name, "Disc %i", menu.disc+1);
-			}
-			else if (selected==ITEM_SAVE || selected==ITEM_LOAD) {
+				sprintf(disc_name, "Disc %i", menu.disc + 1);
+			} else if (selected == ITEM_SAVE || selected == ITEM_LOAD) {
 				menu.slot += 1;
-				if (menu.slot>=MENU_SLOT_COUNT) menu.slot -= MENU_SLOT_COUNT;
+				if (menu.slot >= MENU_SLOT_COUNT) menu.slot -= MENU_SLOT_COUNT;
 				dirty = 1;
 			}
 		}
-		
-		if (dirty && (selected==ITEM_SAVE || selected==ITEM_LOAD)) {
+
+		if (dirty && (selected == ITEM_SAVE || selected == ITEM_LOAD)) {
 			Menu_updateState();
 		}
-		
-		if (PAD_justPressed(BTN_B) || (BTN_WAKE!=BTN_MENU && PAD_tappedMenu(now))) {
+
+		if (PAD_justPressed(BTN_B) ||
+			(BTN_WAKE != BTN_MENU && PAD_tappedMenu(now))) {
 			status = STATUS_CONT;
 			show_menu = 0;
-		}
-		else if (PAD_justPressed(BTN_A)) {
-			switch(selected) {
+		} else if (PAD_justPressed(BTN_A)) {
+			switch (selected) {
 				case ITEM_CONT:
-				if (menu.total_discs && rom_disc!=menu.disc) {
+					if (menu.total_discs && rom_disc != menu.disc) {
 						status = STATUS_DISC;
 						char* disc_path = menu.disc_paths[menu.disc];
 						Game_changeDisc(disc_path);
-					}
-					else {
+					} else {
 						status = STATUS_CONT;
 					}
 					show_menu = 0;
-				break;
-				
+					break;
+
 				case ITEM_SAVE: {
 					Menu_saveState();
 					status = STATUS_SAVE;
 					show_menu = 0;
-				}
-				break;
+				} break;
 				case ITEM_LOAD: {
 					Menu_loadState();
 					status = STATUS_LOAD;
 					show_menu = 0;
-				}
-				break;
+				} break;
 				case ITEM_OPTS: {
 					if (simple_mode) {
 						core.reset();
 						status = STATUS_RESET;
 						show_menu = 0;
-					}
-					else {
+					} else {
 						int old_scaling = screen_scaling;
 						Menu_options(&options_menu);
-						if (screen_scaling!=old_scaling) {
-							selectScaler(renderer.true_w,renderer.true_h,renderer.src_p);
-						
+						if (screen_scaling != old_scaling) {
+							selectScaler(renderer.true_w, renderer.true_h,
+										 renderer.src_p);
+
 							restore_w = screen->w;
 							restore_h = screen->h;
 							restore_p = screen->pitch;
-							screen = GFX_resize(DEVICE_WIDTH,DEVICE_HEIGHT,DEVICE_PITCH);
-						
+							screen = GFX_resize(DEVICE_WIDTH, DEVICE_HEIGHT,
+												DEVICE_PITCH);
+
 							SDL_FillRect(backing, NULL, 0);
 							Menu_scale(menu.bitmap, backing);
 						}
 						dirty = 1;
 					}
-				}
-				break;
+				} break;
 				case ITEM_QUIT:
 					status = STATUS_QUIT;
 					show_menu = 0;
-					quit = 1; // TODO: tmp?
-				break;
+					quit = 1;  // TODO: tmp?
+					break;
 			}
 			if (!show_menu) break;
 		}
 
 		PWR_update(&dirty, &show_setting, Menu_beforeSleep, Menu_afterSleep);
-		
+
 		if (dirty) {
 			GFX_clear(screen);
-			
+
 			SDL_BlitSurface(backing, NULL, screen, NULL);
 			SDL_BlitSurface(menu.overlay, NULL, screen, NULL);
 
 			int ox, oy;
 			int ow = GFX_blitHardwareGroup(screen, show_setting);
 			int max_width = screen->w - SCALE1(PADDING * 2) - ow;
-			
+
 			char display_name[256];
-			int text_width = GFX_truncateText(font.large, rom_name, display_name, max_width, SCALE1(BUTTON_PADDING*2));
+			int text_width =
+				GFX_truncateText(font.large, rom_name, display_name, max_width,
+								 SCALE1(BUTTON_PADDING * 2));
 			max_width = MIN(max_width, text_width);
 
 			SDL_Surface* text;
-			text = TTF_RenderUTF8_Blended(font.large, display_name, COLOR_WHITE);
-			GFX_blitPill(ASSET_BLACK_PILL, screen, &(SDL_Rect){
-				SCALE1(PADDING),
-				SCALE1(PADDING),
-				max_width,
-				SCALE1(PILL_SIZE)
-			});
-			SDL_BlitSurface(text, &(SDL_Rect){
-				0,
-				0,
-				max_width-SCALE1(BUTTON_PADDING*2),
-				text->h
-			}, screen, &(SDL_Rect){
-				SCALE1(PADDING+BUTTON_PADDING),
-				SCALE1(PADDING+4)
-			});
+			text =
+				TTF_RenderUTF8_Blended(font.large, display_name, COLOR_WHITE);
+			GFX_blitPill(ASSET_BLACK_PILL, screen,
+						 &(SDL_Rect){SCALE1(PADDING), SCALE1(PADDING),
+									 max_width, SCALE1(PILL_SIZE)});
+			SDL_BlitSurface(
+				text,
+				&(SDL_Rect){0, 0, max_width - SCALE1(BUTTON_PADDING * 2),
+							text->h},
+				screen,
+				&(SDL_Rect){SCALE1(PADDING + BUTTON_PADDING),
+							SCALE1(PADDING + 4)});
 			SDL_FreeSurface(text);
-			
-			if (show_setting && !GetHDMI()) GFX_blitHardwareHints(screen, show_setting);
-			else GFX_blitButtonGroup((char*[]){ BTN_SLEEP==BTN_POWER?"POWER":"MENU","SLEEP", NULL }, 0, screen, 0);
-			GFX_blitButtonGroup((char*[]){ "B","BACK", "A","OKAY", NULL }, 1, screen, 1);
-			
+
+			if (show_setting && !GetHDMI())
+				GFX_blitHardwareHints(screen, show_setting);
+			else
+				GFX_blitButtonGroup(
+					(char*[]){BTN_SLEEP == BTN_POWER ? "POWER" : "MENU",
+							  "SLEEP", NULL},
+					0, screen, 0);
+			GFX_blitButtonGroup((char*[]){"B", "BACK", "A", "OKAY", NULL}, 1,
+								screen, 1);
+
 			// list
-			oy = (((DEVICE_HEIGHT / FIXED_SCALE) - PADDING * 2) - (MENU_ITEM_COUNT * PILL_SIZE)) / 2;
-			for (int i=0; i<MENU_ITEM_COUNT; i++) {
+			oy = (((DEVICE_HEIGHT / FIXED_SCALE) - PADDING * 2) -
+				  (MENU_ITEM_COUNT * PILL_SIZE)) /
+				 2;
+			for (int i = 0; i < MENU_ITEM_COUNT; i++) {
 				char* item = menu.items[i];
 				SDL_Color text_color = COLOR_WHITE;
-				
-				if (i==selected) {
+
+				if (i == selected) {
 					// disc change
-					if (menu.total_discs>1 && i==ITEM_CONT) {				
-						GFX_blitPill(ASSET_DARK_GRAY_PILL, screen, &(SDL_Rect){
-							SCALE1(PADDING),
-							SCALE1(oy + PADDING),
-							screen->w - SCALE1(PADDING * 2),
-							SCALE1(PILL_SIZE)
-						});
-						text = TTF_RenderUTF8_Blended(font.large, disc_name, COLOR_WHITE);
-						SDL_BlitSurface(text, NULL, screen, &(SDL_Rect){
-							screen->w - SCALE1(PADDING + BUTTON_PADDING) - text->w,
-							SCALE1(oy + PADDING + 4)
-						});
+					if (menu.total_discs > 1 && i == ITEM_CONT) {
+						GFX_blitPill(
+							ASSET_DARK_GRAY_PILL, screen,
+							&(SDL_Rect){SCALE1(PADDING), SCALE1(oy + PADDING),
+										screen->w - SCALE1(PADDING * 2),
+										SCALE1(PILL_SIZE)});
+						text = TTF_RenderUTF8_Blended(font.large, disc_name,
+													  COLOR_WHITE);
+						SDL_BlitSurface(
+							text, NULL, screen,
+							&(SDL_Rect){screen->w -
+											SCALE1(PADDING + BUTTON_PADDING) -
+											text->w,
+										SCALE1(oy + PADDING + 4)});
 						SDL_FreeSurface(text);
 					}
-					
+
 					TTF_SizeUTF8(font.large, item, &ow, NULL);
-					ow += SCALE1(BUTTON_PADDING*2);
-					
+					ow += SCALE1(BUTTON_PADDING * 2);
+
 					// pill
-					GFX_blitPill(ASSET_WHITE_PILL, screen, &(SDL_Rect){
-						SCALE1(PADDING),
-						SCALE1(oy + PADDING + (i * PILL_SIZE)),
-						ow,
-						SCALE1(PILL_SIZE)
-					});
+					GFX_blitPill(
+						ASSET_WHITE_PILL, screen,
+						&(SDL_Rect){SCALE1(PADDING),
+									SCALE1(oy + PADDING + (i * PILL_SIZE)), ow,
+									SCALE1(PILL_SIZE)});
 					text_color = COLOR_BLACK;
-				}
-				else {
+				} else {
 					// shadow
-					text = TTF_RenderUTF8_Blended(font.large, item, COLOR_BLACK);
-					SDL_BlitSurface(text, NULL, screen, &(SDL_Rect){
-						SCALE1(2 + PADDING + BUTTON_PADDING),
-						SCALE1(1 + PADDING + oy + (i * PILL_SIZE) + 4)
-					});
+					text =
+						TTF_RenderUTF8_Blended(font.large, item, COLOR_BLACK);
+					SDL_BlitSurface(
+						text, NULL, screen,
+						&(SDL_Rect){
+							SCALE1(2 + PADDING + BUTTON_PADDING),
+							SCALE1(1 + PADDING + oy + (i * PILL_SIZE) + 4)});
 					SDL_FreeSurface(text);
 				}
-				
+
 				// text
 				text = TTF_RenderUTF8_Blended(font.large, item, text_color);
-				SDL_BlitSurface(text, NULL, screen, &(SDL_Rect){
-					SCALE1(PADDING + BUTTON_PADDING),
-					SCALE1(oy + PADDING + (i * PILL_SIZE) + 4)
-				});
+				SDL_BlitSurface(
+					text, NULL, screen,
+					&(SDL_Rect){SCALE1(PADDING + BUTTON_PADDING),
+								SCALE1(oy + PADDING + (i * PILL_SIZE) + 4)});
 				SDL_FreeSurface(text);
 			}
-			
+
 			// slot preview
-			if (selected==ITEM_SAVE || selected==ITEM_LOAD) {
-				#define WINDOW_RADIUS 4 // TODO: this logic belongs in blitRect?
-				#define PAGINATION_HEIGHT 6
+			if (selected == ITEM_SAVE || selected == ITEM_LOAD) {
+#define WINDOW_RADIUS 4	 // TODO: this logic belongs in blitRect?
+#define PAGINATION_HEIGHT 6
 				// unscaled
 				int hw = DEVICE_WIDTH / 2;
 				int hh = DEVICE_HEIGHT / 2;
-				int pw = hw + SCALE1(WINDOW_RADIUS*2);
-				int ph = hh + SCALE1(WINDOW_RADIUS*2 + PAGINATION_HEIGHT + WINDOW_RADIUS);
+				int pw = hw + SCALE1(WINDOW_RADIUS * 2);
+				int ph = hh + SCALE1(WINDOW_RADIUS * 2 + PAGINATION_HEIGHT +
+									 WINDOW_RADIUS);
 				ox = DEVICE_WIDTH - pw - SCALE1(PADDING);
 				oy = (DEVICE_HEIGHT - ph) / 2;
-				
+
 				// window
-				GFX_blitRect(ASSET_STATE_BG, screen, &(SDL_Rect){ox,oy,pw,ph});
+				GFX_blitRect(ASSET_STATE_BG, screen,
+							 &(SDL_Rect){ox, oy, pw, ph});
 				ox += SCALE1(WINDOW_RADIUS);
 				oy += SCALE1(WINDOW_RADIUS);
-				
-				if (menu.preview_exists) { // has save, has preview
+
+				if (menu.preview_exists) {	// has save, has preview
 					// lotta memory churn here
 					SDL_Surface* bmp = IMG_Load(menu.bmp_path);
-					SDL_Surface* raw_preview = SDL_ConvertSurface(bmp, screen->format, SDL_SWSURFACE);
-					
-					// LOG_info("raw_preview %ix%i\n", raw_preview->w,raw_preview->h);
-					
+					SDL_Surface* raw_preview =
+						SDL_ConvertSurface(bmp, screen->format, SDL_SWSURFACE);
+
+					// LOG_info("raw_preview %ix%i\n",
+					// raw_preview->w,raw_preview->h);
+
 					SDL_FillRect(preview, NULL, 0);
 					Menu_scale(raw_preview, preview);
-					SDL_BlitSurface(preview, NULL, screen, &(SDL_Rect){ox,oy});
+					SDL_BlitSurface(preview, NULL, screen, &(SDL_Rect){ox, oy});
 					SDL_FreeSurface(raw_preview);
 					SDL_FreeSurface(bmp);
-				}
-				else {
-					SDL_Rect preview_rect = {ox,oy,hw,hh};
+				} else {
+					SDL_Rect preview_rect = {ox, oy, hw, hh};
 					SDL_FillRect(screen, &preview_rect, 0);
-					if (menu.save_exists) GFX_blitMessage(font.large, "No Preview", screen, &preview_rect);
-					else GFX_blitMessage(font.large, "Empty Slot", screen, &preview_rect);
+					if (menu.save_exists)
+						GFX_blitMessage(font.large, "No Preview", screen,
+										&preview_rect);
+					else
+						GFX_blitMessage(font.large, "Empty Slot", screen,
+										&preview_rect);
 				}
-				
+
 				// pagination
-				ox += (pw-SCALE1(15*MENU_SLOT_COUNT))/2;
-				oy += hh+SCALE1(WINDOW_RADIUS);
-				for (int i=0; i<MENU_SLOT_COUNT; i++) {
-					if (i==menu.slot)GFX_blitAsset(ASSET_PAGE, NULL, screen, &(SDL_Rect){ox+SCALE1(i*15),oy});
-					else GFX_blitAsset(ASSET_DOT, NULL, screen, &(SDL_Rect){ox+SCALE1(i*15)+4,oy+SCALE1(2)});
+				ox += (pw - SCALE1(15 * MENU_SLOT_COUNT)) / 2;
+				oy += hh + SCALE1(WINDOW_RADIUS);
+				for (int i = 0; i < MENU_SLOT_COUNT; i++) {
+					if (i == menu.slot)
+						GFX_blitAsset(ASSET_PAGE, NULL, screen,
+									  &(SDL_Rect){ox + SCALE1(i * 15), oy});
+					else
+						GFX_blitAsset(ASSET_DOT, NULL, screen,
+									  &(SDL_Rect){ox + SCALE1(i * 15) + 4,
+												  oy + SCALE1(2)});
 				}
 			}
-	
+
 			GFX_flip(screen);
 			dirty = 0;
-		}
-		else GFX_sync();
+		} else
+			GFX_sync();
 		hdmimon();
 	}
-	
+
 	SDL_FreeSurface(preview);
-	
+
 	PAD_reset();
 
 	GFX_clearAll();
 	PWR_warn(1);
-	
+
 	if (!quit) {
-		if (restore_w!=DEVICE_WIDTH || restore_h!=DEVICE_HEIGHT) {
-			screen = GFX_resize(restore_w,restore_h,restore_p);
+		if (restore_w != DEVICE_WIDTH || restore_h != DEVICE_HEIGHT) {
+			screen = GFX_resize(restore_w, restore_h, restore_p);
 		}
 		GFX_setEffect(screen_effect);
 		GFX_clear(screen);
-		video_refresh_callback(renderer.src, renderer.true_w, renderer.true_h, renderer.src_p);
-		
-		setOverclock(overclock); // restore overclock value
+		video_refresh_callback(renderer.src, renderer.true_w, renderer.true_h,
+							   renderer.src_p);
+
+		setOverclock(overclock);  // restore overclock value
 		if (rumble_strength) VIB_setStrength(rumble_strength);
-		
+
 		GFX_setVsync(prevent_tearing);
 		if (!HAS_POWER_BUTTON) PWR_disableSleep();
 
@@ -4563,9 +4759,10 @@ static void Menu_loop(void) {
 			should_run_core = 1;
 			pthread_mutex_unlock(&core_mx);
 		}
-	}
-	else if (exists(NOUI_PATH)) PWR_powerOff(); // TODO: won't work with threaded core, only check this once per launch
-	
+	} else if (exists(NOUI_PATH))
+		PWR_powerOff();	 // TODO: won't work with threaded core, only check this
+						 // once per launch
+
 	SDL_FreeSurface(menu.bitmap);
 	menu.bitmap = NULL;
 	SDL_FreeSurface(backing);
@@ -4573,26 +4770,24 @@ static void Menu_loop(void) {
 }
 
 // TODO: move to PWR_*?
-static unsigned getUsage(void) { // from picoarch
+static unsigned getUsage(void) {  // from picoarch
 	long unsigned ticks = 0;
 	long ticksps = 0;
-	FILE *file = NULL;
+	FILE* file = NULL;
 
 	file = fopen("/proc/self/stat", "r");
-	if (!file)
-		goto finish;
+	if (!file) goto finish;
 
-	if (!fscanf(file, "%*d %*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu", &ticks))
+	if (!fscanf(file, "%*d %*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu",
+				&ticks))
 		goto finish;
 
 	ticksps = sysconf(_SC_CLK_TCK);
 
-	if (ticksps)
-		ticks = ticks * 100 / ticksps;
+	if (ticksps) ticks = ticks * 100 / ticksps;
 
 finish:
-	if (file)
-		fclose(file);
+	if (file) fclose(file);
 
 	return ticks;
 }
@@ -4601,7 +4796,7 @@ static void trackFPS(void) {
 	cpu_ticks += 1;
 	static int last_use_ticks = 0;
 	uint32_t now = SDL_GetTicks();
-	if (now - sec_start>=1000) {
+	if (now - sec_start >= 1000) {
 		double last_time = (double)(now - sec_start) / 1000;
 		fps_double = fps_ticks / last_time;
 		cpu_double = cpu_ticks / last_time;
@@ -4613,7 +4808,7 @@ static void trackFPS(void) {
 		sec_start = now;
 		cpu_ticks = 0;
 		fps_ticks = 0;
-		
+
 		// LOG_info("fps: %f cpu: %f\n", fps_double, cpu_double);
 	}
 }
@@ -4622,19 +4817,21 @@ static void limitFF(void) {
 	static uint64_t ff_frame_time = 0;
 	static uint64_t last_time = 0;
 	static int last_max_speed = -1;
-	if (last_max_speed!=max_ff_speed) {
+	if (last_max_speed != max_ff_speed) {
 		last_max_speed = max_ff_speed;
 		ff_frame_time = 1000000 / (core.fps * (max_ff_speed + 1));
 	}
-	
+
 	uint64_t now = getMicroseconds();
 	if (fast_forward && max_ff_speed) {
 		if (last_time == 0) last_time = now;
 		int elapsed = now - last_time;
-		if (elapsed>0 && elapsed<0x80000) {
-			if (elapsed<ff_frame_time) {
+		if (elapsed > 0 && elapsed < 0x80000) {
+			if (elapsed < ff_frame_time) {
 				int delay = (ff_frame_time - elapsed) / 1000;
-				if (delay>0 && delay<17) { // don't allow a delay any greater than a frame
+				if (delay > 0 &&
+					delay <
+						17) {  // don't allow a delay any greater than a frame
 					SDL_Delay(delay);
 				}
 			}
@@ -4645,18 +4842,18 @@ static void limitFF(void) {
 	last_time = now;
 }
 
-static void* coreThread(void *arg) {
+static void* coreThread(void* arg) {
 	// force a vsync immediately before loop
 	// for better frame pacing?
 	GFX_clearAll();
 	GFX_flip(screen);
-	
+
 	while (!quit) {
 		int run = 0;
 		pthread_mutex_lock(&core_mx);
 		run = should_run_core;
 		pthread_mutex_unlock(&core_mx);
-		
+
 		if (run) {
 			core.run();
 			limitFF();
@@ -4666,22 +4863,22 @@ static void* coreThread(void *arg) {
 	pthread_exit(NULL);
 }
 
-int main(int argc , char* argv[]) {
+int main(int argc, char* argv[]) {
 	LOG_info("MinArch\n");
 
-	setOverclock(overclock); // default to normal
+	setOverclock(overclock);  // default to normal
 	// force a stack overflow to ensure asan is linked and actually working
 	// char tmp[2];
 	// tmp[2] = 'a';
-	
+
 	char core_path[MAX_PATH];
-	char rom_path[MAX_PATH]; 
+	char rom_path[MAX_PATH];
 	char tag_name[MAX_PATH];
-	
+
 	strcpy(core_path, argv[1]);
 	strcpy(rom_path, argv[2]);
 	getEmuName(rom_path, tag_name);
-	
+
 	LOG_info("rom_path: %s\n", rom_path);
 
 	screen = GFX_init(MODE_MENU);
@@ -4689,68 +4886,72 @@ int main(int argc , char* argv[]) {
 	DEVICE_WIDTH = screen->w;
 	DEVICE_HEIGHT = screen->h;
 	DEVICE_PITCH = screen->pitch;
-	// LOG_info("DEVICE_SIZE: %ix%i (%i)\n", DEVICE_WIDTH,DEVICE_HEIGHT,DEVICE_PITCH);
-	
+	// LOG_info("DEVICE_SIZE: %ix%i (%i)\n",
+	// DEVICE_WIDTH,DEVICE_HEIGHT,DEVICE_PITCH);
+
 	VIB_init();
 	PWR_init();
 	if (!HAS_POWER_BUTTON) PWR_disableSleep();
 	MSG_init();
-	
+
 	// Overrides_init();
-	
+
 	Core_open(core_path, tag_name);
-	Game_open(rom_path); // nes tries to load gamegenie setting before this returns ffs
+	Game_open(rom_path);  // nes tries to load gamegenie setting before this
+						  // returns ffs
 	if (!game.is_open) goto finish;
-	
+
 	simple_mode = exists(SIMPLE_MODE_PATH);
-	
+
 	// restore options
-	Config_load(); // before init?
+	Config_load();	// before init?
 	Config_init();
-	Config_readOptions(); // cores with boot logo option (eg. gb) need to load options early
+	Config_readOptions();  // cores with boot logo option (eg. gb) need to load
+						   // options early
 	setOverclock(overclock);
 	GFX_setVsync(prevent_tearing);
-	
+
 	Core_init();
-	
+
 	// TODO: find a better place to do this
 	// mixing static and loaded data is messy
 	// why not move to Core_init()?
 	// ah, because it's defined before options_menu...
 	options_menu.items[1].desc = (char*)core.version;
-	
+
 	Core_load();
 	Input_init(NULL);
-	Config_readOptions(); // but others load and report options later (eg. nes)
-	Config_readControls(); // restore controls (after the core has reported its defaults)
+	Config_readOptions();  // but others load and report options later (eg. nes)
+	Config_readControls();	// restore controls (after the core has reported its
+							// defaults)
 	Config_free();
-		
+
 	SND_init(core.sample_rate, core.fps);
-	InitSettings(); // after we initialize audio
+	InitSettings();	 // after we initialize audio
 	Menu_init();
 	State_resume();
-	Menu_initState(); // make ready for state shortcuts
-	
+	Menu_initState();  // make ready for state shortcuts
+
 	if (thread_video) {
 		core_mx = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
 		core_rq = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
 		pthread_create(&core_pt, NULL, &coreThread, NULL);
 	}
-	
+
 	PWR_warn(1);
 	PWR_disableAutosleep();
-	
+
 	// force a vsync immediately before loop
 	// for better frame pacing?
 	GFX_clearAll();
 	GFX_flip(screen);
-	
-	Special_init(); // after config
-	
+
+	Special_init();	 // after config
+
 	sec_start = SDL_GetTicks();
 	while (!quit) {
 		GFX_startFrame();
-		
+
 		if (!thread_video) {
 			core.run();
 			limitFF();
@@ -4759,39 +4960,41 @@ int main(int argc , char* argv[]) {
 
 		if (thread_video && !quit) {
 			pthread_mutex_lock(&core_mx);
-			pthread_cond_wait(&core_rq,&core_mx);
-			
+			pthread_cond_wait(&core_rq, &core_mx);
+
 			if (backbuffer) {
-				video_refresh_callback_main(backbuffer->pixels,backbuffer->w,backbuffer->h,backbuffer->pitch);
+				video_refresh_callback_main(backbuffer->pixels, backbuffer->w,
+											backbuffer->h, backbuffer->pitch);
 				GFX_flip(screen);
 			}
 			core_rq = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
 			pthread_mutex_unlock(&core_mx);
 		}
-		
+
 		if (show_menu) Menu_loop();
-		
+
 		if (toggle_thread) {
 			toggle_thread = 0;
 			if (was_threaded && !thread_video) {
-				// LOG_info("was fast forwarding while previously threaded (%i) so re-enabling threading %i\n", thread_video, !thread_video);
+				// LOG_info("was fast forwarding while previously threaded (%i)
+				// so re-enabling threading %i\n", thread_video, !thread_video);
 				// revert to pre-fast_forward state before toggling
 				was_threaded = 0;
 				thread_video = !thread_video;
 			}
-			// LOG_info("toggling thread from %i to %i\n", thread_video, !thread_video);
+			// LOG_info("toggling thread from %i to %i\n", thread_video,
+			// !thread_video);
 			thread_video = !thread_video;
 			if (thread_video) {
 				// enable
 				core_mx = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
 				core_rq = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
 				pthread_create(&core_pt, NULL, &coreThread, NULL);
-			}
-			else {
+			} else {
 				// disable
 				pthread_cancel(core_pt);
-				pthread_join(core_pt,NULL);
-				
+				pthread_join(core_pt, NULL);
+
 				// force a vsync immediately before loop
 				// for better frame pacing?
 				GFX_clearAll();
@@ -4799,23 +5002,23 @@ int main(int argc , char* argv[]) {
 			}
 		}
 		// LOG_info("frame duration: %ims\n", SDL_GetTicks()-frame_start);
-		
+
 		hdmimon();
 	}
-	
+
 	Menu_quit();
 	QuitSettings();
-	
+
 finish:
 
 	Game_close();
 	Core_unload();
-	
+
 	Core_quit();
 	Core_close();
-	
+
 	Config_quit();
-	
+
 	Special_quit();
 
 	MSG_quit();
@@ -4824,8 +5027,8 @@ finish:
 	SND_quit();
 	PAD_quit();
 	GFX_quit();
-	
+
 	buffer_dealloc();
-	
+
 	return EXIT_SUCCESS;
 }

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -2813,9 +2813,11 @@ static void video_refresh_callback_main(const void *data, unsigned width, unsign
 		int scale = renderer.scale;
 		if (scale==-1) scale = 1; // nearest neighbor flag
 		
-		// sprintf(debug_text, "%ix%i %ix", renderer.src_w,renderer.src_h, scale);
-		sprintf(debug_text, "%.05f/%i/%i", currentratio, currentbufferfree,currentframecount);
+		sprintf(debug_text, "%ix%i %ix", renderer.src_w,renderer.src_h, scale);
 		blitBitmapText(debug_text,x,y,(uint16_t*)data,pitch/2, width,height);
+
+		sprintf(debug_text, "%.03f/%i//%.03f", currentratio, currentbufferfree,currentfps);
+		blitBitmapText(debug_text,x,y*2.2,(uint16_t*)data,pitch/2, width,height);
 
 		sprintf(debug_text, "%i,%i %ix%i", renderer.dst_x,renderer.dst_y, renderer.src_w*scale,renderer.src_h*scale);
 		blitBitmapText(debug_text,-x,y,(uint16_t*)data,pitch/2, width,height);

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -2813,7 +2813,8 @@ static void video_refresh_callback_main(const void *data, unsigned width, unsign
 		int scale = renderer.scale;
 		if (scale==-1) scale = 1; // nearest neighbor flag
 		
-		sprintf(debug_text, "%ix%i %ix", renderer.src_w,renderer.src_h, scale);
+		// sprintf(debug_text, "%ix%i %ix", renderer.src_w,renderer.src_h, scale);
+		sprintf(debug_text, "%.05f/%i/%i", currentratio, currentbufferfree,currentframecount);
 		blitBitmapText(debug_text,x,y,(uint16_t*)data,pitch/2, width,height);
 
 		sprintf(debug_text, "%i,%i %ix%i", renderer.dst_x,renderer.dst_y, renderer.src_w*scale,renderer.src_h*scale);
@@ -2821,6 +2822,8 @@ static void video_refresh_callback_main(const void *data, unsigned width, unsign
 	
 		sprintf(debug_text, "%.01f/%.01f %i%%", fps_double, cpu_double, (int)use_double);
 		blitBitmapText(debug_text,x,-y,(uint16_t*)data,pitch/2, width,height);
+
+	
 	
 		sprintf(debug_text, "%ix%i", renderer.dst_w,renderer.dst_h);
 		blitBitmapText(debug_text,-x,-y,(uint16_t*)data,pitch/2, width,height);

--- a/workspace/tg5040/platform/platform.h
+++ b/workspace/tg5040/platform/platform.h
@@ -134,7 +134,7 @@ extern int is_brick;
 
 #define SDCARD_PATH "/mnt/SDCARD"
 #define MUTE_VOLUME_RAW 0
-#define SAMPLES 256
+#define SAMPLES 512
 ///////////////////////////////
 
 #endif

--- a/workspace/tg5040/platform/platform.h
+++ b/workspace/tg5040/platform/platform.h
@@ -134,7 +134,7 @@ extern int is_brick;
 
 #define SDCARD_PATH "/mnt/SDCARD"
 #define MUTE_VOLUME_RAW 0
-
+#define SAMPLES 256
 ///////////////////////////////
 
 #endif


### PR DESCRIPTION
Your audio implemtation limits the main loop to the core's FPS, so vsync is never working. Like for example SNES core runs at 59fps and because your audio waits for it to finish it will never run above 59fps and if your screen is 60fps it will never be synced and you see stutters.

I completely rewrote the audio system and it now uses libsamplerate and dynamic ratio adjustment to exactly match the correct FPS of your device. So now emulation will run true in sync with your screen's FPS and also audio is adjusted dynamically based on detected FPS not just hardcoded fps. So even screens which have like 60.23 refresh rate the emulation and audio will stay in sync.

Too many changes to explain, just look at code!
You need libsamplerate installed in your toolchains to compile