### PR TITLE
feat: initialize is_brick in PLAT_initInput for cli-only tools

### DIFF
--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -24,6 +24,9 @@ int is_brick = 0;
 
 static SDL_Joystick *joystick;
 void PLAT_initInput(void) {
+	char* device = getenv("DEVICE");
+	is_brick = exactMatch("brick", device);
+
 	SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 	joystick = SDL_JoystickOpen(0);
 }


### PR DESCRIPTION
On the Trimui Brick (`tg3050`) the `L3 and R3` buttons are _only_ detected when there `GFX_init` - and therefore `PLAT_initVideo` - is called. This means that for cli-only tools - such as my `minui-btntest` project, which waits for buttons to be pressed and exits - the `L3` and `R3` button is not detected.

This PR adds the detection to `PLAT_initInput`, enabling access to the L3/R3 buttons on third-party cli tools for MinUI.