### PR TITLE
fix: do not kill wifi in a loop

### DIFF
--- a/skeleton/SYSTEM/my282/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/my282/paks/MinUI.pak/launch.sh
@@ -28,12 +28,9 @@ reclock
 
 killall -9 tee
 rm -f "$SDCARD_PATH/update.log"
-while :; do
-	killall -9 wpa_supplicant
-	killall -9 MtpDaemon
-	ifconfig wlan0 down
-	sleep 2
-done &
+killall -9 MtpDaemon
+killall -9 wpa_supplicant
+ifconfig wlan0 down
 
 #######################################
 


### PR DESCRIPTION
On all other devices where this logic is implemented - trimuismart, tg5040 - wifi is not terminated in a loop. This change removes that loop so that paks can re-enable wifi on their own as needed.

I personally think the ideal case is that either all devices have wifi disabled once on boot, or none of them do. I'd be in favor of all of them having wifi disabled once on boot, and then let users with custom paks figure out how to re-enable wifi as needed. Happy to change the PR to better standardize against the desired behavior though.