### PR TITLE
fix: add missing GFX_startFrame to minput.c

### DIFF
--- a/workspace/all/minput/minput.c
+++ b/workspace/all/minput/minput.c
@@ -71,6 +71,7 @@ int main(int argc , char* argv[]) {
 	// int show_setting = 0;
 	// int was_online = PLAT_isOnline();
 	while(!quit) {
+		GFX_startFrame();
 		uint32_t frame_start = SDL_GetTicks();
 		
 		PAD_poll();


### PR DESCRIPTION
This should be performed at the beginning of the render loop to ensure `GFX_sync()` works on devices without vsync.

While I don't know which devices this impacts, I figured it was best to add it since it was [mentioned in discord](https://discord.com/channels/741895796315914271/1095561573046685696/1332313950573957193) that it was missing.