### PR TITLE
Tg5040 stop wpa fix

### DIFF
--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -89,7 +89,15 @@ rfkill block bluetooth
 rfkill block wifi
 killall udhcpc
 killall MtpDaemon
-/etc/init.d/wpa_supplicant stop # not sure this is working
+# Wait for wpa_supplicant to fully start before attempting to stop it
+for i in $(seq 1 10); do
+    if pgrep -x "wpa_supplicant" > /dev/null; then
+        echo "Stopping wpa_supplicant" > /dev/console
+        /etc/init.d/wpa_supplicant stop
+        break
+    fi
+    sleep 0.25
+done
 
 keymon.elf & # &> $SDCARD_PATH/keymon.txt &
 

--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -90,7 +90,7 @@ rfkill block wifi
 killall udhcpc
 killall MtpDaemon
 for i in $(seq 1 10); do
-    if ps | grep "{S[0-9]*wpa_supplica}" | grep -v grep > /dev/null; then
+    if pgrep -f "S[0-9]*wpa_supplicant" > /dev/null; then
         sleep 0.25
         continue
     fi

--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -92,7 +92,6 @@ killall MtpDaemon
 # Wait for wpa_supplicant to fully start before attempting to stop it
 for i in $(seq 1 10); do
     if pgrep -x "wpa_supplicant" > /dev/null; then
-        echo "Stopping wpa_supplicant" > /dev/console
         /etc/init.d/wpa_supplicant stop
         break
     fi

--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -89,14 +89,14 @@ rfkill block bluetooth
 rfkill block wifi
 killall udhcpc
 killall MtpDaemon
-# Wait for wpa_supplicant to fully start before attempting to stop it
 for i in $(seq 1 10); do
-    if pgrep -x "wpa_supplicant" > /dev/null; then
-        /etc/init.d/wpa_supplicant stop
-        break
+    if ps | grep "{S[0-9]*wpa_supplica}" | grep -v grep > /dev/null; then
+        sleep 0.25
+        continue
     fi
-    sleep 0.25
+    break
 done
+/etc/init.d/wpa_supplicant stop
 
 keymon.elf & # &> $SDCARD_PATH/keymon.txt &
 


### PR DESCRIPTION
I noticed that comment regarding stopping wpa_supplicant in launch.sh for the Brick, and I found on my device that it was not being stopped.

Right now when it's currently being stopped, it hasn't fully started running.  Below are two prints of 'ps | grep wpa', one from before it has fully started (when it is currently being stopped) and again after it is running and can be successfully stopped.

 1829 root      3972 S    {S96wpa_supplica} /bin/sh /etc/rc.common /etc/rc.d/S

 2394 root      3892 S    wpa_supplicant -iwlan0 -Dnl80211 -c/etc/wifi/wpa_sup

My change just loops for up to 2.5 seconds waiting for wpa_supplicant to be running before stopping it.

Possibly related to #33