### PR TITLE
fix: set the online status based on the operating state of the wlan0 device

### DIFF
--- a/workspace/my282/platform/platform.c
+++ b/workspace/my282/platform/platform.c
@@ -666,9 +666,9 @@ void PLAT_getBatteryStatus(int* is_charging, int* charge) {
 	else           *charge =  10;
 
 	// wifi status, just hooking into the regular PWR polling
-	// char status[16];
-	// getFile("/sys/class/net/wlan0/operstate", status,16);
-	// online = prefixMatch("up", status);
+	char status[16];
+	getFile("/sys/class/net/wlan0/operstate", status,16);
+	online = prefixMatch("up", status);
 }
 
 #define LED_PATH "/sys/class/leds/led1/brightness"


### PR DESCRIPTION
While by default wifi is disabled on the my282 (a30) platform, it can be enabled by modifying the MinUI launch.sh to disable killing wifi aggressively. This change merely ensures we respect the wifi setting in the UI, which may be desirable for those with newer firmware versions.