### PR TITLE
Fix miyoo flip right stick axis swapped

### DIFF
--- a/workspace/my355/platform/platform.h
+++ b/workspace/my355/platform/platform.h
@@ -93,8 +93,8 @@
 
 #define AXIS_LX	0
 #define AXIS_LY	1
-#define AXIS_RX	4
-#define AXIS_RY	3
+#define AXIS_RX	3
+#define AXIS_RY	4
 
 ///////////////////////////////
 


### PR DESCRIPTION
According to some users on discord the right stick has horizontal and vertical axis swapped. 

https://discord.com/channels/741895796315914271/1095561573046685696/1377786577203494982