### PR TITLE
rg35xxplus: fix poweroff race condition causing erroneous restart

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -558,6 +558,10 @@ static void State_write(void) { // from picoarch
 		goto error;
 	}
 
+	// Ensure data is flushed to disk before closing
+	fflush(state_file);
+	fsync(fileno(state_file));
+
 error:
 	if (state) free(state);
 	if (state_file) fclose(state_file);
@@ -3115,6 +3119,10 @@ void Menu_beforeSleep(void) {
 	RTC_write();
 	State_autosave();
 	putFile(AUTO_RESUME_PATH, game.path + strlen(SDCARD_PATH));
+
+	// Ensure all file operations are committed to disk before power-off
+	sync();
+
 	PWR_setCPUSpeed(CPU_SPEED_MENU);
 }
 void Menu_afterSleep(void) {

--- a/workspace/rg35xx/platform/platform.c
+++ b/workspace/rg35xx/platform/platform.c
@@ -550,6 +550,10 @@ void PLAT_enableBacklight(int enable) {
 	putInt("/sys/class/backlight/backlight.2/bl_power", enable ? FB_BLANK_UNBLANK : FB_BLANK_POWERDOWN);
 }
 void PLAT_powerOff(void) {
+	// First sync to ensure all pending writes are committed
+	sync();
+
+	// Give filesystem time to complete all writes (especially important for slow SD cards)
 	sleep(2);
 
 	SetRawVolume(MUTE_VOLUME_RAW);
@@ -558,7 +562,10 @@ void PLAT_powerOff(void) {
 	VIB_quit();
 	PWR_quit();
 	GFX_quit();
-	
+
+	// Final sync before shutdown
+	sync();
+
 	system("shutdown");
 }
 

--- a/workspace/rg35xxplus/boot/boot.sh
+++ b/workspace/rg35xxplus/boot/boot.sh
@@ -129,6 +129,11 @@ else
 	fi
 fi
 
-sync && poweroff
+sync
+poweroff
+
+# wait for poweroff
+# exiting can lead to erroneous restart
+sleep 60
 
 exit 0

--- a/workspace/rg35xxplus/platform/platform.c
+++ b/workspace/rg35xxplus/platform/platform.c
@@ -917,7 +917,14 @@ void PLAT_enableBacklight(int enable) {
 }
 
 void PLAT_powerOff(void) {
-	system("rm -f /tmp/minui_exec && sync");
+	// First sync to ensure all pending writes are committed
+	sync();
+
+	// Remove the exec marker file and sync again
+	system("rm -f /tmp/minui_exec");
+	sync();
+
+	// Give filesystem time to complete all writes (especially important for slow SD cards)
 	sleep(2);
 
 	SetRawVolume(MUTE_VOLUME_RAW);
@@ -927,6 +934,9 @@ void PLAT_powerOff(void) {
 	VIB_quit();
 	PWR_quit();
 	GFX_quit();
+
+	// Final sync before exit
+	sync();
 
 	// system("cat /dev/zero > /dev/fb0 2>/dev/null");
 	// system("shutdown");


### PR DESCRIPTION
Fixes a race condition on rg35xxplus where dmenu.bin sometimes exits before shutdown / poweroff had completed, leading to init re-starting dmenu.bin rather than finishing shutdown / poweroff.

Also adds additional syncs to prevent observed loss of save state on poweroff.