### PR TITLE
rg35xxplus: fix shutdown race condition causing erroneous restart

### DIFF
--- a/skeleton/SYSTEM/rg35xxplus/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/rg35xxplus/paks/MinUI.pak/launch.sh
@@ -86,3 +86,7 @@ while [ -f "$EXEC_PATH" ]; do
 done
 
 shutdown
+
+# wait for shutdown
+# exiting can lead to erroneous restart
+sleep 60


### PR DESCRIPTION
Fixes a race condition on rg35xxplus where MinUI sometimes exits before poweroff had completed, leading to init re-starting MinUI rather than finishing poweroff.

Replaces #55 with just the poweroff-focused commit.